### PR TITLE
Fix tarot deck hash generation script

### DIFF
--- a/scripts/generateCardHashes.js
+++ b/scripts/generateCardHashes.js
@@ -1,20 +1,16 @@
-// api/userHash.js
+const fs = require('fs');
 const crypto = require('crypto');
 
-module.exports = (req, res) => {
-  // Vercel sets x-forwarded-for to the real client IP
-  const forwarded = req.headers['x-forwarded-for'];
-  const ip = forwarded
-    ? forwarded.split(',')[0].trim()
-    : req.connection.remoteAddress || '0.0.0.0';
+const deckPath = 'src/data/deckTarot.json';
+const deck = JSON.parse(fs.readFileSync(deckPath, 'utf8'));
 
-  const userHash = crypto
+for (const card of deck.cards) {
+  const hash = crypto
     .createHash('sha256')
-    .update(ip)
-    .digest('hex')
-    .substring(0, 16);
+    .update(card.name)
+    .digest('hex');
+  card.hash64 = hash; // 64 hex characters
+}
 
-  // cache briefly at the edge
-  res.setHeader('Cache-Control', 's-maxage=10, stale-while-revalidate');
-  res.status(200).json({ userHash });
-};
+fs.writeFileSync(deckPath, JSON.stringify(deck, null, 2));
+console.log(`Updated ${deck.cards.length} cards with hash64 values.`);

--- a/src/data/deckTarot.json
+++ b/src/data/deckTarot.json
@@ -7,44 +7,49 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m00.jpg",
-	  "fortune_telling": [
-                "Watch for new projects and new beginnings", 
-                "Prepare to take something on faith", 
-                "Something new comes your way; go for it"
-            ], 
-            "keywords": [
-                "freedom", 
-                "faith", 
-                "inexperience", 
-                "innocence"
-            ], 
-            "meanings": {
-                "light": [
-                    "Freeing yourself from limitation", 
-                    "Expressing joy and youthful vigor", 
-                    "Being open-minded", 
-                    "Taking a leap of faith", 
-                    "Attuning yourself to your instincts", 
-                    "Being eager or curious", 
-                    "Exploring your potential", 
-                    "Embracing innovation and change"
-                ], 
-                "shadow": [
-                    "Being gullible and naive", 
-                    "Taking unnecessary risks", 
-                    "Failing to be serious when required", 
-                    "Being silly or distracted", 
-                    "Lacking experience", 
-                    "Failing to honor well-established traditions and limits", 
-                    "Behaving inappropriately"
-                ]
-            },
-		"Archetype": "The Divine Madman",
-		"Hebrew Alphabet": "Aleph/Ox/1",
-		"Numerology": "0 (off the scale; pure potential)",
-		"Elemental": "Air",
-		"Mythical/Spiritual": "Adam before the fall. Christ as a wandering holy madman. Deity wrapped in human flesh. The Holy Spirit.",
-      "Questions to Ask" : ["What would I do if I felt free to take a leap?","How willing am I to be vulnerable and open?","How might past experiences help in this new situation?"]       	
+      "fortune_telling": [
+        "Watch for new projects and new beginnings",
+        "Prepare to take something on faith",
+        "Something new comes your way; go for it"
+      ],
+      "keywords": [
+        "freedom",
+        "faith",
+        "inexperience",
+        "innocence"
+      ],
+      "meanings": {
+        "light": [
+          "Freeing yourself from limitation",
+          "Expressing joy and youthful vigor",
+          "Being open-minded",
+          "Taking a leap of faith",
+          "Attuning yourself to your instincts",
+          "Being eager or curious",
+          "Exploring your potential",
+          "Embracing innovation and change"
+        ],
+        "shadow": [
+          "Being gullible and naive",
+          "Taking unnecessary risks",
+          "Failing to be serious when required",
+          "Being silly or distracted",
+          "Lacking experience",
+          "Failing to honor well-established traditions and limits",
+          "Behaving inappropriately"
+        ]
+      },
+      "Archetype": "The Divine Madman",
+      "Hebrew Alphabet": "Aleph/Ox/1",
+      "Numerology": "0 (off the scale; pure potential)",
+      "Elemental": "Air",
+      "Mythical/Spiritual": "Adam before the fall. Christ as a wandering holy madman. Deity wrapped in human flesh. The Holy Spirit.",
+      "Questions to Ask": [
+        "What would I do if I felt free to take a leap?",
+        "How willing am I to be vulnerable and open?",
+        "How might past experiences help in this new situation?"
+      ],
+      "hash64": "20d665c91916141ca983358746dafe9877349e042c2215b7fb7f52791be83631"
     },
     {
       "name": "The Magician",
@@ -52,38 +57,44 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m01.jpg",
-	  "fortune_telling": [
-                "A powerful man may play a role in your day", 
-                "Your current situation must be seen as one element of a much larger plan"
-            ], 
-            "keywords": [
-                "capability", 
-                "empowerment", 
-                "activity"
-            ], 
-            "meanings": {
-                "light": [
-                    "Taking appropriate action", 
-                    "Receiving guidance from a higher power", 
-                    "Becoming a channel of divine will", 
-                    "Expressing masculine energy in appropriate and constructive ways", 
-                    "Being yourself in every way"
-                ], 
-                "shadow": [
-                    "Inflating your own ego", 
-                    "Abusing talents", 
-                    "Manipulating or deceiving others", 
-                    "Being too aggressive", 
-                    "Using cheap illusions to dazzle others", 
-                    "Refusing to invest the time and effort needed to master your craft", 
-                    "Taking shortcuts"
-                ]
-            },
-		"Archetype" : "The Ego/The Self",
-		"Hebrew Alphabet" : "Beth/House/2",
-		"Numerology" : "1 (origins, unity, seeds)",
-		"Elemental" : "The Sun/Mercury",		"Mythical/Spiritual" : "Thoth, the Egyptian god of wisdom, known to the Greeks as Hermes and to the Romans as Mercury. Christ working miracles. Brahma, the Creator.",
-		"Questions to Ask" : ["What am I empowered to do?","How might my abilities come into play?","To what extent am I making the most of my talents?"]
+      "fortune_telling": [
+        "A powerful man may play a role in your day",
+        "Your current situation must be seen as one element of a much larger plan"
+      ],
+      "keywords": [
+        "capability",
+        "empowerment",
+        "activity"
+      ],
+      "meanings": {
+        "light": [
+          "Taking appropriate action",
+          "Receiving guidance from a higher power",
+          "Becoming a channel of divine will",
+          "Expressing masculine energy in appropriate and constructive ways",
+          "Being yourself in every way"
+        ],
+        "shadow": [
+          "Inflating your own ego",
+          "Abusing talents",
+          "Manipulating or deceiving others",
+          "Being too aggressive",
+          "Using cheap illusions to dazzle others",
+          "Refusing to invest the time and effort needed to master your craft",
+          "Taking shortcuts"
+        ]
+      },
+      "Archetype": "The Ego/The Self",
+      "Hebrew Alphabet": "Beth/House/2",
+      "Numerology": "1 (origins, unity, seeds)",
+      "Elemental": "The Sun/Mercury",
+      "Mythical/Spiritual": "Thoth, the Egyptian god of wisdom, known to the Greeks as Hermes and to the Romans as Mercury. Christ working miracles. Brahma, the Creator.",
+      "Questions to Ask": [
+        "What am I empowered to do?",
+        "How might my abilities come into play?",
+        "To what extent am I making the most of my talents?"
+      ],
+      "hash64": "153faaa4274831ac81d20efa34d4209c163390474c3f3b0e92eb4ad0e6b8681d"
     },
     {
       "name": "The High Priestess",
@@ -91,42 +102,47 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m02.jpg",
-	  "fortune_telling": [
-                "A mysterious woman arrives", 
-                "A sexual secret may surface", 
-                "Someone knows more than he or she will reveal"
-            ], 
-            "keywords": [
-                "intuition", 
-                "reflection", 
-                "purity", 
-                "initiation"
-            ], 
-            "meanings": {
-                "light": [
-                    "Listening to your feelings and intuitions", 
-                    "Exploring unconventional spirituality", 
-                    "Keeping secrets", 
-                    "Being receptive", 
-                    "Reflecting instead of acting", 
-                    "Observing others", 
-                    "Preserving purity"
-                ], 
-                "shadow": [
-                    "Being aloof", 
-                    "Obsessing on secrets and conspiracies", 
-                    "Rejecting guidance from spirit or intuition", 
-                    "Revealing all", 
-                    "Ignoring gut feelings", 
-                    "Refusing to become involved, even when involvement is appropriate"
-                ]
-            },
-		"Archetype" : "The Virgin/The Maiden",
-      "Hebrew Alphabet" : "Gimel/Camel/3",
-      "Numerology" : "2 (division, debate, duality)",
-      "Elemental" : "The Moon",
-      "Mythical/Spiritual" : "The feminine aspect of divinity, particularity when expressed through virginity, as with the Virgin Mary or Isis.",
-	  "Questions to Ask" : ["What might a rebel against tradition do?","What isn't being said or revealed?","What could be achieved by observing and reflecting?"]
+      "fortune_telling": [
+        "A mysterious woman arrives",
+        "A sexual secret may surface",
+        "Someone knows more than he or she will reveal"
+      ],
+      "keywords": [
+        "intuition",
+        "reflection",
+        "purity",
+        "initiation"
+      ],
+      "meanings": {
+        "light": [
+          "Listening to your feelings and intuitions",
+          "Exploring unconventional spirituality",
+          "Keeping secrets",
+          "Being receptive",
+          "Reflecting instead of acting",
+          "Observing others",
+          "Preserving purity"
+        ],
+        "shadow": [
+          "Being aloof",
+          "Obsessing on secrets and conspiracies",
+          "Rejecting guidance from spirit or intuition",
+          "Revealing all",
+          "Ignoring gut feelings",
+          "Refusing to become involved, even when involvement is appropriate"
+        ]
+      },
+      "Archetype": "The Virgin/The Maiden",
+      "Hebrew Alphabet": "Gimel/Camel/3",
+      "Numerology": "2 (division, debate, duality)",
+      "Elemental": "The Moon",
+      "Mythical/Spiritual": "The feminine aspect of divinity, particularity when expressed through virginity, as with the Virgin Mary or Isis.",
+      "Questions to Ask": [
+        "What might a rebel against tradition do?",
+        "What isn't being said or revealed?",
+        "What could be achieved by observing and reflecting?"
+      ],
+      "hash64": "338e3e4c594ed54de45326c34f98d98516cf0be012f79bb9338de0a894099e4a"
     },
     {
       "name": "The Empress",
@@ -134,43 +150,48 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m03.jpg",
-	  "fortune_telling": [
-                "Pregnancy is in the cards", 
-                "An opportunity to be involved in luxurious sexuality is coming", 
-                "Beware a tendency toward addiction"
-            ], 
-            "keywords": [
-                "fertility", 
-                "productivity", 
-                "ripeness", 
-                "nurturing"
-            ], 
-            "meanings": {
-                "light": [
-                    "Nurturing yourself and others", 
-                    "Bearing fruit", 
-                    "Celebrating your body", 
-                    "Bearing (literal or figurative) children", 
-                    "Reveling in luxury", 
-                    "Mothering those around you in positive ways", 
-                    "Enjoying your sexuality", 
-                    "Getting things done"
-                ], 
-                "shadow": [
-                    "Overindulging", 
-                    "Being greedy", 
-                    "Smothering someone with attention", 
-                    "Debilitating someone by being overprotective", 
-                    "Inhibiting productivity by obsessing on productivity", 
-                    "Being overcome by addictive behavior"
-                ]
-            },
-		"Archetype" : "The Mother",
-      "Hebrew Alphabet" : "Daleth/Door/4",
-      "Numerology" : "3 (expression, productivity, output)",
-      "Elemental" : "Venus",
-      "Mythical/Spiritual" : "Gaia, Mother Earth, Ishtar, DemeterÑmature, reproductive female divinity in every form. Also Aphrodite and Turan. ",
-	  "Questions to Ask" : ["What would a concerned and capable mother do?","What can I do that would emphasize growth?","How can I celebrate my own sensuality and sexuality?"]
+      "fortune_telling": [
+        "Pregnancy is in the cards",
+        "An opportunity to be involved in luxurious sexuality is coming",
+        "Beware a tendency toward addiction"
+      ],
+      "keywords": [
+        "fertility",
+        "productivity",
+        "ripeness",
+        "nurturing"
+      ],
+      "meanings": {
+        "light": [
+          "Nurturing yourself and others",
+          "Bearing fruit",
+          "Celebrating your body",
+          "Bearing (literal or figurative) children",
+          "Reveling in luxury",
+          "Mothering those around you in positive ways",
+          "Enjoying your sexuality",
+          "Getting things done"
+        ],
+        "shadow": [
+          "Overindulging",
+          "Being greedy",
+          "Smothering someone with attention",
+          "Debilitating someone by being overprotective",
+          "Inhibiting productivity by obsessing on productivity",
+          "Being overcome by addictive behavior"
+        ]
+      },
+      "Archetype": "The Mother",
+      "Hebrew Alphabet": "Daleth/Door/4",
+      "Numerology": "3 (expression, productivity, output)",
+      "Elemental": "Venus",
+      "Mythical/Spiritual": "Gaia, Mother Earth, Ishtar, DemeterÑmature, reproductive female divinity in every form. Also Aphrodite and Turan. ",
+      "Questions to Ask": [
+        "What would a concerned and capable mother do?",
+        "What can I do that would emphasize growth?",
+        "How can I celebrate my own sensuality and sexuality?"
+      ],
+      "hash64": "ff7853d1f9a11efe885f16139e57831b058edadd3bec6b9d9901d69ba1b4e21d"
     },
     {
       "name": "The Emperor",
@@ -178,40 +199,45 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m04.jpg",
-	  "fortune_telling": [
-                "A father figure arrives", 
-                "A new employer or authority figure will give you orders", 
-                "Expect discipline or correction in the near future"
-            ], 
-            "keywords": [
-                "authority", 
-                "regulation", 
-                "direction", 
-                "structure"
-            ], 
-            "meanings": {
-                "light": [
-                    "Exercising authority", 
-                    "Defining limits", 
-                    "Directing the flow of work", 
-                    "Communicating clear guidelines", 
-                    "Being in control of yourself and others", 
-                    "Tempering aggressive masculinity with wisdom and experience"
-                ], 
-                "shadow": [
-                    "Micromanaging", 
-                    "Crushing the creativity of others with a rigid, iron-fisted approach", 
-                    "Insisting on getting your own way", 
-                    "Assuming a dictatorial mindset", 
-                    "Using overt force to achieve your goals and maintain order"
-                ]
-            },
-		"Archetype" : "The Father",
-      "Hebrew Alphabet" : "He[as]/Window/5, or in some decks, Tzaddi/Fish hook/90",
-      "Numerology" : "4 (stability, equality, persistence)",
-      "Elemental" : "Mars/Aries",
-      "Mythical/Spiritual" : "Masculine gods, including the Hebrew God, the Christian God, Allah, and Zeus. Patriarchs (Abraham) and lawgivers (Moses). Vishnu, the Preserver.",
-	  "Questions to Ask" : ["How does the issue of control or regulation impact this situation?","What would a compassionate but strict father do?","What needs more control?"]
+      "fortune_telling": [
+        "A father figure arrives",
+        "A new employer or authority figure will give you orders",
+        "Expect discipline or correction in the near future"
+      ],
+      "keywords": [
+        "authority",
+        "regulation",
+        "direction",
+        "structure"
+      ],
+      "meanings": {
+        "light": [
+          "Exercising authority",
+          "Defining limits",
+          "Directing the flow of work",
+          "Communicating clear guidelines",
+          "Being in control of yourself and others",
+          "Tempering aggressive masculinity with wisdom and experience"
+        ],
+        "shadow": [
+          "Micromanaging",
+          "Crushing the creativity of others with a rigid, iron-fisted approach",
+          "Insisting on getting your own way",
+          "Assuming a dictatorial mindset",
+          "Using overt force to achieve your goals and maintain order"
+        ]
+      },
+      "Archetype": "The Father",
+      "Hebrew Alphabet": "He[as]/Window/5, or in some decks, Tzaddi/Fish hook/90",
+      "Numerology": "4 (stability, equality, persistence)",
+      "Elemental": "Mars/Aries",
+      "Mythical/Spiritual": "Masculine gods, including the Hebrew God, the Christian God, Allah, and Zeus. Patriarchs (Abraham) and lawgivers (Moses). Vishnu, the Preserver.",
+      "Questions to Ask": [
+        "How does the issue of control or regulation impact this situation?",
+        "What would a compassionate but strict father do?",
+        "What needs more control?"
+      ],
+      "hash64": "2999d4b853d445c0615371322941ccaa481302296b07192967cfacd9fae37708"
     },
     {
       "name": "The Hierophant",
@@ -219,42 +245,47 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m05.jpg",
-	  "fortune_telling": [
-                "Expect to be caught in a misdeed and punished accordingly", 
-                "Pray for forgiveness and confess wrongdoings", 
-                "A more experienced man, spiritual leader, or father figure will come into your life"
-            ], 
-            "keywords": [
-                "guidance", 
-                "knowledge", 
-                "revelation", 
-                "belief"
-            ], 
-            "meanings": {
-                "light": [
-                    "Teaching or guiding others", 
-                    "Searching for the truth", 
-                    "Asking for guidance from a higher power", 
-                    "Acknowledging the wisdom and experience of others", 
-                    "Taking vows", 
-                    "Engaging in heartfelt rituals", 
-                    "Volunteering"
-                ], 
-                "shadow": [
-                    "Using experience as a means of manipulating or misguiding others", 
-                    "Being dogmatic", 
-                    "Favoring tradition over what is expedient or necessary", 
-                    "Going through the motions of empty rituals", 
-                    "Concealing wisdom", 
-                    "Restricting access to spiritual truths or the gods"
-                ]
-            },
-		"Archetype" : "The Guardian/The Church/Faith",
-      "Hebrew Alphabet" : "Vau/Nail or Spike/6",
-      "Numerology" : "5 (instability, resistance, confrontation, evolution)",
-      "Elemental" : "Taurus/Earth",
-      "Mythical/Spiritual" : "The Christ, the Apostle Peter, Buddha, Mohammed. Popes, priests, and intercessors of every faith and tradition",
-	  "Questions to Ask" : ["What role might tradition or religion play in this situation?","Who authored the rules? Who enforces them? Why?","How might an experienced guide impact this situation?"]
+      "fortune_telling": [
+        "Expect to be caught in a misdeed and punished accordingly",
+        "Pray for forgiveness and confess wrongdoings",
+        "A more experienced man, spiritual leader, or father figure will come into your life"
+      ],
+      "keywords": [
+        "guidance",
+        "knowledge",
+        "revelation",
+        "belief"
+      ],
+      "meanings": {
+        "light": [
+          "Teaching or guiding others",
+          "Searching for the truth",
+          "Asking for guidance from a higher power",
+          "Acknowledging the wisdom and experience of others",
+          "Taking vows",
+          "Engaging in heartfelt rituals",
+          "Volunteering"
+        ],
+        "shadow": [
+          "Using experience as a means of manipulating or misguiding others",
+          "Being dogmatic",
+          "Favoring tradition over what is expedient or necessary",
+          "Going through the motions of empty rituals",
+          "Concealing wisdom",
+          "Restricting access to spiritual truths or the gods"
+        ]
+      },
+      "Archetype": "The Guardian/The Church/Faith",
+      "Hebrew Alphabet": "Vau/Nail or Spike/6",
+      "Numerology": "5 (instability, resistance, confrontation, evolution)",
+      "Elemental": "Taurus/Earth",
+      "Mythical/Spiritual": "The Christ, the Apostle Peter, Buddha, Mohammed. Popes, priests, and intercessors of every faith and tradition",
+      "Questions to Ask": [
+        "What role might tradition or religion play in this situation?",
+        "Who authored the rules? Who enforces them? Why?",
+        "How might an experienced guide impact this situation?"
+      ],
+      "hash64": "c80587d94456f598aa30e107318d6c9f786d7b752d183ccf5aa4184ca41c2d41"
     },
     {
       "name": "The Lovers",
@@ -262,40 +293,45 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m06.jpg",
-	  "fortune_telling": [
-                "A new personal or professional relationship blossoms", 
-                "Sexual opportunities abound", 
-                "Unexpectedly, a friend becomes a lover"
-            ], 
-            "keywords": [
-                "love", 
-                "passion", 
-                "unity", 
-                "choice"
-            ], 
-            "meanings": {
-                "light": [
-                    "Being in love", 
-                    "Showing your love to others", 
-                    "Expressing passion or romantic feelings", 
-                    "Aligning yourself with groups or like-minded others", 
-                    "Bringing people together", 
-                    "Making well-informed decisions"
-                ], 
-                "shadow": [
-                    "Debilitating passion", 
-                    "Allowing an unhealthy desire for love to motivate destructive behavior", 
-                    "Disrupting unity", 
-                    "Working against the best interests of those who care about you", 
-                    "Ill-informed decisions"
-                ]
-            },
-		"Archetype" : "The Lover/Sexual Awakening",
-      "Hebrew Alphabet" : "Zain/Sword/7",
-      "Numerology" : "6 (cooperation, collaboration, interaction)",
-      "Elemental" : "Gemini",
-      "Mythical/Spiritual" : "Obviously, Adam and Eve, who are depicted in RWS-influenced decks. Also Venus and Cupid, Aphrodite and Eros.",
-	  "Questions to Ask" : ["What guides my choices?","What is my heart leading me to do?","How might this decision transform me as a person?"]
+      "fortune_telling": [
+        "A new personal or professional relationship blossoms",
+        "Sexual opportunities abound",
+        "Unexpectedly, a friend becomes a lover"
+      ],
+      "keywords": [
+        "love",
+        "passion",
+        "unity",
+        "choice"
+      ],
+      "meanings": {
+        "light": [
+          "Being in love",
+          "Showing your love to others",
+          "Expressing passion or romantic feelings",
+          "Aligning yourself with groups or like-minded others",
+          "Bringing people together",
+          "Making well-informed decisions"
+        ],
+        "shadow": [
+          "Debilitating passion",
+          "Allowing an unhealthy desire for love to motivate destructive behavior",
+          "Disrupting unity",
+          "Working against the best interests of those who care about you",
+          "Ill-informed decisions"
+        ]
+      },
+      "Archetype": "The Lover/Sexual Awakening",
+      "Hebrew Alphabet": "Zain/Sword/7",
+      "Numerology": "6 (cooperation, collaboration, interaction)",
+      "Elemental": "Gemini",
+      "Mythical/Spiritual": "Obviously, Adam and Eve, who are depicted in RWS-influenced decks. Also Venus and Cupid, Aphrodite and Eros.",
+      "Questions to Ask": [
+        "What guides my choices?",
+        "What is my heart leading me to do?",
+        "How might this decision transform me as a person?"
+      ],
+      "hash64": "355985770dc63e1f28c40e1a690d0d7f35453c27cfee233562809efe45d2b813"
     },
     {
       "name": "The Chariot",
@@ -303,39 +339,44 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m07.jpg",
-	  "fortune_telling": [
-                "Victory is a certainty", 
-                "Move ahead with all plans", 
-                "Beware the jealousy of others"
-            ], 
-            "keywords": [
-                "advancement", 
-                "victory", 
-                "triumph", 
-                "success"
-            ], 
-            "meanings": {
-                "light": [
-                    "Breaking through barriers", 
-                    "Moving forward with confidence and authority", 
-                    "Reaching the pinnacle of success", 
-                    "Basking in the glory of achievement", 
-                    "Guiding an effort to total victory", 
-                    "Establishing yourself as a worthy leader"
-                ], 
-                "shadow": [
-                    "Resting on laurels", 
-                    "Riding roughshod over the feelings or expectations of others", 
-                    "Focusing more on past successes than future opportunities", 
-                    "Failing to rein in impulsive behavior"
-                ]
-            },
-		"Archetype" : "The Victorious Hero",
-      "Hebrew Alphabet" : "Cheth/Fence/8",
-      "Numerology" : "7 (imagination, inner work, psychology)",
-      "Elemental" : "Cancer",
-      "Mythical/Spiritual" : "Odysseus. Jason. The search for the Holy Grail. Christ's triumphal entry into Jerusalem.",
-	  "Questions to Ask" : ["To what extent have I arrived? What will my next challenge be?","How can I use past achievements to their best advantage?","What would the criteria for real and meaningful success be?"]
+      "fortune_telling": [
+        "Victory is a certainty",
+        "Move ahead with all plans",
+        "Beware the jealousy of others"
+      ],
+      "keywords": [
+        "advancement",
+        "victory",
+        "triumph",
+        "success"
+      ],
+      "meanings": {
+        "light": [
+          "Breaking through barriers",
+          "Moving forward with confidence and authority",
+          "Reaching the pinnacle of success",
+          "Basking in the glory of achievement",
+          "Guiding an effort to total victory",
+          "Establishing yourself as a worthy leader"
+        ],
+        "shadow": [
+          "Resting on laurels",
+          "Riding roughshod over the feelings or expectations of others",
+          "Focusing more on past successes than future opportunities",
+          "Failing to rein in impulsive behavior"
+        ]
+      },
+      "Archetype": "The Victorious Hero",
+      "Hebrew Alphabet": "Cheth/Fence/8",
+      "Numerology": "7 (imagination, inner work, psychology)",
+      "Elemental": "Cancer",
+      "Mythical/Spiritual": "Odysseus. Jason. The search for the Holy Grail. Christ's triumphal entry into Jerusalem.",
+      "Questions to Ask": [
+        "To what extent have I arrived? What will my next challenge be?",
+        "How can I use past achievements to their best advantage?",
+        "What would the criteria for real and meaningful success be?"
+      ],
+      "hash64": "2791787e1adf8cb05ee3128df2e1fe33643bdb622f135bcdd34d646b29fb1511"
     },
     {
       "name": "Strength",
@@ -343,38 +384,43 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m08.jpg",
-	   "fortune_telling": [
-                "Your self-control will be tested", 
-                "A woman will seek to change her partner or lover", 
-                "You are a strong, capable person"
-            ], 
-            "keywords": [
-                "discipline", 
-                "boldness", 
-                "self-discipline", 
-                "power", 
-                "vitality"
-            ], 
-            "meanings": {
-                "light": [
-                    "Imposing restrictions on yourself for your own benefit", 
-                    "Bringing your passions under the control of reason", 
-                    "Resisting impulses that work against your best interests", 
-                    "Taking bold action"
-                ], 
-                "shadow": [
-                    "Indulging weakness, even when you know it will damage your health and happiness", 
-                    "Languishing in addiction", 
-                    "Allowing your instincts to tame and conquer you", 
-                    "Failing to take a stand when necessary"
-                ]
-            },
-		"Archetype" : "The Law",
-      "Hebrew Alphabet" : "Lamed/Outstretched Arms/30 or Theth/Snake/9",
-      "Numerology" : "8 (movement, work) or 11 = 1 + 1 = 2 (debate, duality)",
-      "Elemental" : "Libra or Leo",
-      "Mythical/Spiritual" : "Themis or Justitia. Ma'at. Solomon dividing a baby. The Sword of Damocles. The giving of the Ten Commandments.",
-	  "Questions to Ask" : ["To what extent is your life (or work) balanced?","How can you achieve greater objectivity?","What course of action would be fair to everyone concerned?"]
+      "fortune_telling": [
+        "Your self-control will be tested",
+        "A woman will seek to change her partner or lover",
+        "You are a strong, capable person"
+      ],
+      "keywords": [
+        "discipline",
+        "boldness",
+        "self-discipline",
+        "power",
+        "vitality"
+      ],
+      "meanings": {
+        "light": [
+          "Imposing restrictions on yourself for your own benefit",
+          "Bringing your passions under the control of reason",
+          "Resisting impulses that work against your best interests",
+          "Taking bold action"
+        ],
+        "shadow": [
+          "Indulging weakness, even when you know it will damage your health and happiness",
+          "Languishing in addiction",
+          "Allowing your instincts to tame and conquer you",
+          "Failing to take a stand when necessary"
+        ]
+      },
+      "Archetype": "The Law",
+      "Hebrew Alphabet": "Lamed/Outstretched Arms/30 or Theth/Snake/9",
+      "Numerology": "8 (movement, work) or 11 = 1 + 1 = 2 (debate, duality)",
+      "Elemental": "Libra or Leo",
+      "Mythical/Spiritual": "Themis or Justitia. Ma'at. Solomon dividing a baby. The Sword of Damocles. The giving of the Ten Commandments.",
+      "Questions to Ask": [
+        "To what extent is your life (or work) balanced?",
+        "How can you achieve greater objectivity?",
+        "What course of action would be fair to everyone concerned?"
+      ],
+      "hash64": "63ee3a1b965a7bd2581227dff2147a504c3b0926f2120180630fdfe2fc1a5b77"
     },
     {
       "name": "The Hermit",
@@ -382,39 +428,44 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m09.jpg",
-	   "fortune_telling": [
-                "A period of loneliness begins", 
-                "One partner in a relationship departs", 
-                "A search for love or money proves fruitless"
-            ], 
-            "keywords": [
-                "solitude", 
-                "experience", 
-                "stillness", 
-                "withdrawal"
-            ], 
-            "meanings": {
-                "light": [
-                    "Becoming or seeking out a guru", 
-                    "Going on a retreat", 
-                    "Recharging spiritual or creative batteries", 
-                    "Lighting the way for those with less experience", 
-                    "Stepping back to gain perspective"
-                ], 
-                "shadow": [
-                    "Being a loner", 
-                    "Fearing contact with others", 
-                    "Becoming a know-it-all", 
-                    "Inflating claims of expertise", 
-                    "Hiding your skills and talents out of fear of unworthiness"
-                ]
-            },
-		"Archetype" : "The Holy Man",
-      "Hebrew Alphabet" : "Yod/Hand/10",
-      "Numerology" : "9 (fullness, readiness, ripeness)",
-      "Elemental" : "Virgo",
-      "Mythical/Spiritual" : "The Christ, while fasting 40 days in the wilderness. Chronos, the god of time. Father Time. Hermes.",
-	  "Questions to Ask" : ["What would happen if I simply withdrew and took no action?","How can I get some perspective on the situation?","Who has walked this path before me? How can I enlist his or her help?"]
+      "fortune_telling": [
+        "A period of loneliness begins",
+        "One partner in a relationship departs",
+        "A search for love or money proves fruitless"
+      ],
+      "keywords": [
+        "solitude",
+        "experience",
+        "stillness",
+        "withdrawal"
+      ],
+      "meanings": {
+        "light": [
+          "Becoming or seeking out a guru",
+          "Going on a retreat",
+          "Recharging spiritual or creative batteries",
+          "Lighting the way for those with less experience",
+          "Stepping back to gain perspective"
+        ],
+        "shadow": [
+          "Being a loner",
+          "Fearing contact with others",
+          "Becoming a know-it-all",
+          "Inflating claims of expertise",
+          "Hiding your skills and talents out of fear of unworthiness"
+        ]
+      },
+      "Archetype": "The Holy Man",
+      "Hebrew Alphabet": "Yod/Hand/10",
+      "Numerology": "9 (fullness, readiness, ripeness)",
+      "Elemental": "Virgo",
+      "Mythical/Spiritual": "The Christ, while fasting 40 days in the wilderness. Chronos, the god of time. Father Time. Hermes.",
+      "Questions to Ask": [
+        "What would happen if I simply withdrew and took no action?",
+        "How can I get some perspective on the situation?",
+        "Who has walked this path before me? How can I enlist his or her help?"
+      ],
+      "hash64": "68128297103f16ceb6a11e91b9eb93de99edb612ff4c79d0e4504b6922534b80"
     },
     {
       "name": "Wheel of Fortune",
@@ -422,40 +473,45 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m10.jpg",
-	  "fortune_telling": [
-                "Some events are in the hands of heaven", 
-                "You've lived through this before", 
-                "What happened then?"
-            ], 
-            "keywords": [
-                "luck", 
-                "randomness", 
-                "cycles", 
-                "karma", 
-                "fate", 
-                "revolution"
-            ], 
-            "meanings": {
-                "light": [
-                    "Allowing events to unfold", 
-                    "Seeing the larger pattern in everyday events", 
-                    "Trusting your luck", 
-                    "Watching for cycles", 
-                    "Believing that \"what goes around, comes around\""
-                ], 
-                "shadow": [
-                    "Losing money gambling", 
-                    "Refusing to do your part to bring a plan to fruition", 
-                    "Taking a fatalistic approach to life", 
-                    "Fighting the natural course of events"
-                ]
-            },
-		"Archetype" : "The Fates/Destiny",
-      "Hebrew Alphabet" : "Koph/Palm/20",
-      "Numerology" : "10 (finality, completion) and 10 = 1 + 0 = 1 (seed, opportunity)",
-      "Elemental" : "Jupiter",
-      "Mythical/Spiritual" : "The God in the Machine. Deus ex Machina. Clotho, Lachesis, and Atropos. Fortuna.",
-	  "Questions to Ask" : ["How does this challenge fit into a larger pattern?","What role does luck play in my circumstances?","What can I control? How should I know when to relinquish control?"]
+      "fortune_telling": [
+        "Some events are in the hands of heaven",
+        "You've lived through this before",
+        "What happened then?"
+      ],
+      "keywords": [
+        "luck",
+        "randomness",
+        "cycles",
+        "karma",
+        "fate",
+        "revolution"
+      ],
+      "meanings": {
+        "light": [
+          "Allowing events to unfold",
+          "Seeing the larger pattern in everyday events",
+          "Trusting your luck",
+          "Watching for cycles",
+          "Believing that \"what goes around, comes around\""
+        ],
+        "shadow": [
+          "Losing money gambling",
+          "Refusing to do your part to bring a plan to fruition",
+          "Taking a fatalistic approach to life",
+          "Fighting the natural course of events"
+        ]
+      },
+      "Archetype": "The Fates/Destiny",
+      "Hebrew Alphabet": "Koph/Palm/20",
+      "Numerology": "10 (finality, completion) and 10 = 1 + 0 = 1 (seed, opportunity)",
+      "Elemental": "Jupiter",
+      "Mythical/Spiritual": "The God in the Machine. Deus ex Machina. Clotho, Lachesis, and Atropos. Fortuna.",
+      "Questions to Ask": [
+        "How does this challenge fit into a larger pattern?",
+        "What role does luck play in my circumstances?",
+        "What can I control? How should I know when to relinquish control?"
+      ],
+      "hash64": "1150067a35fb852aed86ccf525ae701ca20e402cab900da00c364fa6ee146516"
     },
     {
       "name": "Justice",
@@ -463,40 +519,45 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m11.jpg",
-	  "fortune_telling": [
-                "A legal verdict will be rendered soon", 
-                "Someone is making a decision", 
-                "You need to get the facts"
-            ], 
-            "keywords": [
-                "balance", 
-                "law", 
-                "fairness", 
-                "objectivity"
-            ], 
-            "meanings": {
-                "light": [
-                    "Making an objective decision", 
-                    "Weighing an issue carefully before taking action", 
-                    "Appropriately scaling your reaction to a situation", 
-                    "Getting all the facts", 
-                    "Considering evidence", 
-                    "Deliberating"
-                ], 
-                "shadow": [
-                    "Delivering harsh criticism", 
-                    "Obsessing on rules and regulations", 
-                    "Playing by the book even when it is destructive or counterproductive to do so", 
-                    "Confusing snap decisions with timely action", 
-                    "Playing favorites"
-                ]
-            },
-		"Archetype" : "The Id",
-      "Hebrew Alphabet" : "Theth/Snake/9 or Lamed/Outstretched Arms/30",
-      "Numerology" : "11 = 1 + 1 = 2 (debate, duality) or 8 (movement, outer work)",
-      "Elemental" : "Leo or Libra",
-      "Mythical/Spiritual" : "Samson. Hercules. Daniel in the lion's den. The sinless Christ.",
-	  "Questions to Ask" : ["How can I enhance my self-discipline?","What behaviors tempt me? How can I resist?","What instincts do I continue to struggle with today?"]
+      "fortune_telling": [
+        "A legal verdict will be rendered soon",
+        "Someone is making a decision",
+        "You need to get the facts"
+      ],
+      "keywords": [
+        "balance",
+        "law",
+        "fairness",
+        "objectivity"
+      ],
+      "meanings": {
+        "light": [
+          "Making an objective decision",
+          "Weighing an issue carefully before taking action",
+          "Appropriately scaling your reaction to a situation",
+          "Getting all the facts",
+          "Considering evidence",
+          "Deliberating"
+        ],
+        "shadow": [
+          "Delivering harsh criticism",
+          "Obsessing on rules and regulations",
+          "Playing by the book even when it is destructive or counterproductive to do so",
+          "Confusing snap decisions with timely action",
+          "Playing favorites"
+        ]
+      },
+      "Archetype": "The Id",
+      "Hebrew Alphabet": "Theth/Snake/9 or Lamed/Outstretched Arms/30",
+      "Numerology": "11 = 1 + 1 = 2 (debate, duality) or 8 (movement, outer work)",
+      "Elemental": "Leo or Libra",
+      "Mythical/Spiritual": "Samson. Hercules. Daniel in the lion's den. The sinless Christ.",
+      "Questions to Ask": [
+        "How can I enhance my self-discipline?",
+        "What behaviors tempt me? How can I resist?",
+        "What instincts do I continue to struggle with today?"
+      ],
+      "hash64": "5f9740dd7874801f460dfe0f92e5be0cf2cfd04088d7d5ab996c92a428d3ee8b"
     },
     {
       "name": "The Hanged Man",
@@ -504,40 +565,45 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m12.jpg",
-	  "fortune_telling": [
-                "A traitor is revealed", 
-                "One of your friends is working against you", 
-                "Change your ways or suffer the consequences"
-            ], 
-            "keywords": [
-                "enlightenment", 
-                "sacrifice", 
-                "perspective", 
-                "suspension", 
-                "reversals"
-            ], 
-            "meanings": {
-                "light": [
-                    "Seeing growth opportunities in unpleasant events", 
-                    "Experiencing a dramatic change in personal perspective", 
-                    "Making the best of an unforeseen change in your life or work", 
-                    "Suspending disbelief", 
-                    "Making sacrifices"
-                ], 
-                "shadow": [
-                    "Being untrue to yourself and your values", 
-                    "Refusing to make sacrifices when appropriate", 
-                    "Refusing to adapt to new situations", 
-                    "Blaming others", 
-                    "Profiting at the expense of others"
-                ]
-            },
-		"Archetype" : "The Traitor",
-      "Hebrew Alphabet" : "Mem/Water/40",
-      "Numerology" : "12 = 1 + 2 = 3 (expression, productivity, output)",
-      "Elemental" : "Water",
-      "Mythical/Spiritual" : "The Crucified Christ. Isaac as a sacrifice. Prometheus bound. Jonah and the whale. Lazarus. Any hanged or sacrificed god. Judas.",
-	  "Questions to Ask" : ["How can I radically alter my perspective?","How might being stuck actually be a blessing in disguise?","How can I help myself see the glass as half full?"]
+      "fortune_telling": [
+        "A traitor is revealed",
+        "One of your friends is working against you",
+        "Change your ways or suffer the consequences"
+      ],
+      "keywords": [
+        "enlightenment",
+        "sacrifice",
+        "perspective",
+        "suspension",
+        "reversals"
+      ],
+      "meanings": {
+        "light": [
+          "Seeing growth opportunities in unpleasant events",
+          "Experiencing a dramatic change in personal perspective",
+          "Making the best of an unforeseen change in your life or work",
+          "Suspending disbelief",
+          "Making sacrifices"
+        ],
+        "shadow": [
+          "Being untrue to yourself and your values",
+          "Refusing to make sacrifices when appropriate",
+          "Refusing to adapt to new situations",
+          "Blaming others",
+          "Profiting at the expense of others"
+        ]
+      },
+      "Archetype": "The Traitor",
+      "Hebrew Alphabet": "Mem/Water/40",
+      "Numerology": "12 = 1 + 2 = 3 (expression, productivity, output)",
+      "Elemental": "Water",
+      "Mythical/Spiritual": "The Crucified Christ. Isaac as a sacrifice. Prometheus bound. Jonah and the whale. Lazarus. Any hanged or sacrificed god. Judas.",
+      "Questions to Ask": [
+        "How can I radically alter my perspective?",
+        "How might being stuck actually be a blessing in disguise?",
+        "How can I help myself see the glass as half full?"
+      ],
+      "hash64": "a367c96f8a9b13d8680c12bd7e5a23cdeca7e2cb209a1bf6dfbcc1e573bad2ba"
     },
     {
       "name": "Death",
@@ -545,40 +611,45 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m13.jpg",
-	  "fortune_telling": [
-                "A relationship or illness ends suddenly", 
-                "Limit travel and risk-taking", 
-                "General gloom and doom"
-            ], 
-            "keywords": [
-                "ending", 
-                "conclusion", 
-                "transition", 
-                "passage", 
-                "departure"
-            ], 
-            "meanings": {
-                "light": [
-                    "Bringing an unpleasant phase of life to an end", 
-                    "Recognizing and celebrating the conclusion of something", 
-                    "Putting bad habits to rest", 
-                    "Becoming a new person", 
-                    "Leaving one person, place, or thing for another", 
-                    "Letting go"
-                ], 
-                "shadow": [
-                    "Obsessing on death and dying", 
-                    "Refusing to give up old habits or unhealthy relationships", 
-                    "Insisting that everything and everyone should stay the same forever", 
-                    "Failing to take good care of yourself"
-                ]
-            },
-		"Archetype" : "Death",
-      "Hebrew Alphabet" : "Nun/Fish/50",
-      "Numerology" : "13 = 1 + 3 = 4 (stability, persistence)",
-      "Elemental" : "Scorpio",
-      "Mythical/Spiritual" : "Christ in the tomb. Hades. Hypnos. Thanatos. Stories of journeys into the underworld.",
-	  "Questions to Ask" : ["What needs to end?","How might an ending actually be a blessing in this situation?","What's next?"]
+      "fortune_telling": [
+        "A relationship or illness ends suddenly",
+        "Limit travel and risk-taking",
+        "General gloom and doom"
+      ],
+      "keywords": [
+        "ending",
+        "conclusion",
+        "transition",
+        "passage",
+        "departure"
+      ],
+      "meanings": {
+        "light": [
+          "Bringing an unpleasant phase of life to an end",
+          "Recognizing and celebrating the conclusion of something",
+          "Putting bad habits to rest",
+          "Becoming a new person",
+          "Leaving one person, place, or thing for another",
+          "Letting go"
+        ],
+        "shadow": [
+          "Obsessing on death and dying",
+          "Refusing to give up old habits or unhealthy relationships",
+          "Insisting that everything and everyone should stay the same forever",
+          "Failing to take good care of yourself"
+        ]
+      },
+      "Archetype": "Death",
+      "Hebrew Alphabet": "Nun/Fish/50",
+      "Numerology": "13 = 1 + 3 = 4 (stability, persistence)",
+      "Elemental": "Scorpio",
+      "Mythical/Spiritual": "Christ in the tomb. Hades. Hypnos. Thanatos. Stories of journeys into the underworld.",
+      "Questions to Ask": [
+        "What needs to end?",
+        "How might an ending actually be a blessing in this situation?",
+        "What's next?"
+      ],
+      "hash64": "fcd6fea72de7e6c09ca2567674befdef61c04e783bd2e0f092aeb99c57e587e3"
     },
     {
       "name": "Temperance",
@@ -586,42 +657,47 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m14.jpg",
-	  "fortune_telling": [
-                "Someone's using drugs or alcohol to excess", 
-                "It's time to get back on that diet"
-            ], 
-            "keywords": [
-                "blending", 
-                "synthesis", 
-                "mediation", 
-                "combination", 
-                "harmony"
-            ], 
-            "meanings": {
-                "light": [
-                    "Bringing opposites together", 
-                    "Moderating your actions or emotions", 
-                    "Finding middle ground", 
-                    "Reaching compromises", 
-                    "Synthesizing solutions that please everyone involved", 
-                    "Using the old to make something new"
-                ], 
-                "shadow": [
-                    "Going to extremes", 
-                    "Disrupting group efforts", 
-                    "Ignoring healthy approaches to life", 
-                    "Becoming an addict", 
-                    "Practicing gluttony", 
-                    "Tearing something or someone apart", 
-                    "Breaking alliances"
-                ]
-            },
-		"Archetype" : "The Mediator",
-      "Hebrew Alphabet" : "Samekh/Foundation/60",
-      "Numerology" : "14 = 1 + 4 = 5 (catalyst, instability, confrontation)",
-      "Elemental" : "Sagittarius",
-      "Mythical/Spiritual" : "The angel seen here may be the goddess Iris. By extension, priests, priesthoods, or the transfigured Christ.",
-	  "Questions to Ask" : ["How can I avoid extremes?","What does everyone involved have in common?","How might combining familiar things help me create something new?"]
+      "fortune_telling": [
+        "Someone's using drugs or alcohol to excess",
+        "It's time to get back on that diet"
+      ],
+      "keywords": [
+        "blending",
+        "synthesis",
+        "mediation",
+        "combination",
+        "harmony"
+      ],
+      "meanings": {
+        "light": [
+          "Bringing opposites together",
+          "Moderating your actions or emotions",
+          "Finding middle ground",
+          "Reaching compromises",
+          "Synthesizing solutions that please everyone involved",
+          "Using the old to make something new"
+        ],
+        "shadow": [
+          "Going to extremes",
+          "Disrupting group efforts",
+          "Ignoring healthy approaches to life",
+          "Becoming an addict",
+          "Practicing gluttony",
+          "Tearing something or someone apart",
+          "Breaking alliances"
+        ]
+      },
+      "Archetype": "The Mediator",
+      "Hebrew Alphabet": "Samekh/Foundation/60",
+      "Numerology": "14 = 1 + 4 = 5 (catalyst, instability, confrontation)",
+      "Elemental": "Sagittarius",
+      "Mythical/Spiritual": "The angel seen here may be the goddess Iris. By extension, priests, priesthoods, or the transfigured Christ.",
+      "Questions to Ask": [
+        "How can I avoid extremes?",
+        "What does everyone involved have in common?",
+        "How might combining familiar things help me create something new?"
+      ],
+      "hash64": "dba646c42f79ae40a017c4526636a66478b7c485c1d87b620989002ff2049f24"
     },
     {
       "name": "The Devil",
@@ -629,41 +705,46 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m15.jpg",
-	  "fortune_telling": [
-                "Adultery and unfaithfulness", 
-                "A string of extremely bad luck is coming your way", 
-                "Beware evil influences and wolves in sheep's clothing"
-            ], 
-            "keywords": [
-                "shadow", 
-                "materialism", 
-                "bondage", 
-                "delusion"
-            ], 
-            "meanings": {
-                "light": [
-                    "Appreciating the luxuries that life has to offer", 
-                    "Being comfortable in your own skin", 
-                    "Enjoying your sexuality", 
-                    "Splurging on an expensive personal item", 
-                    "Embracing the fact that everyone has a darker side", 
-                    "Dealing with unhealthy impulses in healthy ways"
-                ], 
-                "shadow": [
-                    "Putting excessive emphasis on appearances", 
-                    "Always wanting more", 
-                    "Valuing possessions more than people or relationships", 
-                    "Allowing base instincts to govern your life", 
-                    "Being selfish", 
-                    "Attributing your own dark impulses to outside forces or other people"
-                ]
-            },
-		"Archetype" : "The Shadow, The Other",
-      "Hebrew Alphabet" : "Ayin/Eye/70",
-      "Numerology" : "15 = 1 + 5 = 6 (adjustment, collaboration)",
-      "Elemental" : "Capricorn",
-      "Mythical/Spiritual" : "The Biblical Satan, certainly. Fallen angels, including Lucifer. Bacchus and Pan. Tempters and serpents of every stripe.",
-	  "Questions to Ask" : ["What enslaves me? How can I set myself free?","How can I re-evaluate the importance I assign to material things?","To what extent do my cravings define me?"]
+      "fortune_telling": [
+        "Adultery and unfaithfulness",
+        "A string of extremely bad luck is coming your way",
+        "Beware evil influences and wolves in sheep's clothing"
+      ],
+      "keywords": [
+        "shadow",
+        "materialism",
+        "bondage",
+        "delusion"
+      ],
+      "meanings": {
+        "light": [
+          "Appreciating the luxuries that life has to offer",
+          "Being comfortable in your own skin",
+          "Enjoying your sexuality",
+          "Splurging on an expensive personal item",
+          "Embracing the fact that everyone has a darker side",
+          "Dealing with unhealthy impulses in healthy ways"
+        ],
+        "shadow": [
+          "Putting excessive emphasis on appearances",
+          "Always wanting more",
+          "Valuing possessions more than people or relationships",
+          "Allowing base instincts to govern your life",
+          "Being selfish",
+          "Attributing your own dark impulses to outside forces or other people"
+        ]
+      },
+      "Archetype": "The Shadow, The Other",
+      "Hebrew Alphabet": "Ayin/Eye/70",
+      "Numerology": "15 = 1 + 5 = 6 (adjustment, collaboration)",
+      "Elemental": "Capricorn",
+      "Mythical/Spiritual": "The Biblical Satan, certainly. Fallen angels, including Lucifer. Bacchus and Pan. Tempters and serpents of every stripe.",
+      "Questions to Ask": [
+        "What enslaves me? How can I set myself free?",
+        "How can I re-evaluate the importance I assign to material things?",
+        "To what extent do my cravings define me?"
+      ],
+      "hash64": "6ecd69087817ca922b1ee438e9f30c2a333622904146fc0861ebc7175c3192af"
     },
     {
       "name": "The Tower",
@@ -671,42 +752,47 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m16.jpg",
-	  "fortune_telling": [
-                "Impending disaster", 
-                "Cancel plans and reverse decisions", 
-                "Someone wants to take you down a notch or two", 
-                "Don't hold back; say what you really mean"
-            ], 
-            "keywords": [
-                "demolition", 
-                "upheaval", 
-                "deconstruction", 
-                "disaster", 
-                "destruction"
-            ], 
-            "meanings": {
-                "light": [
-                    "Breaking out of old, confining habits and mindsets", 
-                    "Clearing the way for new growth", 
-                    "Dispelling the influence of an inflated ego", 
-                    "Getting back to basics", 
-                    "Stripping away harmful illusions", 
-                    "Receiving sudden insight"
-                ], 
-                "shadow": [
-                    "Clinging to traditions that repress growth", 
-                    "Engaging in willful blindness", 
-                    "Rejecting evidence that change is needed", 
-                    "Ignoring guidance from a higher power", 
-                    "Maliciously engaging in destructive behavior"
-                ]
-            },
-		"Archetype" : "The Shattered Ego",
-      "Hebrew Alphabet" : "Pe[as]/Open Mouth/80",
-      "Numerology" : "16 = 1 + 6 = 7 (psychology, imagination, inner work)",
-      "Elemental" : "Mars",
-      "Mythical/Spiritual" : "The Tower of Babel. The destruction of Sodom and Gomorrah. Shiva's destructive dance. The lightning of Zeus and Thor.",
-	  "Questions to Ask" : ["How might the current situation dramatically alter my perspective?","How might this loss open the door for new growth?","What attitudes need to be struck down before I proceed?"]
+      "fortune_telling": [
+        "Impending disaster",
+        "Cancel plans and reverse decisions",
+        "Someone wants to take you down a notch or two",
+        "Don't hold back; say what you really mean"
+      ],
+      "keywords": [
+        "demolition",
+        "upheaval",
+        "deconstruction",
+        "disaster",
+        "destruction"
+      ],
+      "meanings": {
+        "light": [
+          "Breaking out of old, confining habits and mindsets",
+          "Clearing the way for new growth",
+          "Dispelling the influence of an inflated ego",
+          "Getting back to basics",
+          "Stripping away harmful illusions",
+          "Receiving sudden insight"
+        ],
+        "shadow": [
+          "Clinging to traditions that repress growth",
+          "Engaging in willful blindness",
+          "Rejecting evidence that change is needed",
+          "Ignoring guidance from a higher power",
+          "Maliciously engaging in destructive behavior"
+        ]
+      },
+      "Archetype": "The Shattered Ego",
+      "Hebrew Alphabet": "Pe[as]/Open Mouth/80",
+      "Numerology": "16 = 1 + 6 = 7 (psychology, imagination, inner work)",
+      "Elemental": "Mars",
+      "Mythical/Spiritual": "The Tower of Babel. The destruction of Sodom and Gomorrah. Shiva's destructive dance. The lightning of Zeus and Thor.",
+      "Questions to Ask": [
+        "How might the current situation dramatically alter my perspective?",
+        "How might this loss open the door for new growth?",
+        "What attitudes need to be struck down before I proceed?"
+      ],
+      "hash64": "699c520b932dd7b7cd109500bf8231cda667a94dd70da850b8fef1f5e94a1136"
     },
     {
       "name": "The Star",
@@ -714,43 +800,48 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m17.jpg",
-	  "fortune_telling": [
-                "Get an astrology chart drawn up", 
-                "Someone is a little too starstruck", 
-                "What's happening now has long been fore-ordained"
-            ], 
-            "keywords": [
-                "hope", 
-                "optimism", 
-                "openness", 
-                "certainty", 
-                "faith", 
-                "longing", 
-                "truth"
-            ], 
-            "meanings": {
-                "light": [
-                    "Hoping for the best", 
-                    "Believing good things happen to good people", 
-                    "Seeing events in the best possible light", 
-                    "Adopting a generous spirit", 
-                    "Seeking guidance from above", 
-                    "Embracing possibility over probability"
-                ], 
-                "shadow": [
-                    "Denying unpleasant truths", 
-                    "Denying personal accountability and saying, \"Things just happen!\"",
-                    "Ignoring signs and omens", 
-                    "Preferring illusion to reality", 
-                    "Spreading pessimism and stinginess of spirit"
-                ]
-            },
-		"Archetype" : "The Heavenly Guide",
-      "Hebrew Alphabet" : "Tzaddi/Fishhook/90 or, in some decks, He[as]/Window/5",
-      "Numerology" : "17 = 1 + 7 = 8 (action, movement, swiftness)",
-      "Elemental" : "Aquarius",
-      "Mythical/Spiritual" : "The star that guided the Magi. Aphrodite. Venus. The Pleiades. Moses bringing forth water from the rock.",
-	  "Questions to Ask" : ["What would my higher power direct me to do?","How can I be less self-conscious and guarded?","How can I better attune myself to the abundance of life's blessings?"]
+      "fortune_telling": [
+        "Get an astrology chart drawn up",
+        "Someone is a little too starstruck",
+        "What's happening now has long been fore-ordained"
+      ],
+      "keywords": [
+        "hope",
+        "optimism",
+        "openness",
+        "certainty",
+        "faith",
+        "longing",
+        "truth"
+      ],
+      "meanings": {
+        "light": [
+          "Hoping for the best",
+          "Believing good things happen to good people",
+          "Seeing events in the best possible light",
+          "Adopting a generous spirit",
+          "Seeking guidance from above",
+          "Embracing possibility over probability"
+        ],
+        "shadow": [
+          "Denying unpleasant truths",
+          "Denying personal accountability and saying, \"Things just happen!\"",
+          "Ignoring signs and omens",
+          "Preferring illusion to reality",
+          "Spreading pessimism and stinginess of spirit"
+        ]
+      },
+      "Archetype": "The Heavenly Guide",
+      "Hebrew Alphabet": "Tzaddi/Fishhook/90 or, in some decks, He[as]/Window/5",
+      "Numerology": "17 = 1 + 7 = 8 (action, movement, swiftness)",
+      "Elemental": "Aquarius",
+      "Mythical/Spiritual": "The star that guided the Magi. Aphrodite. Venus. The Pleiades. Moses bringing forth water from the rock.",
+      "Questions to Ask": [
+        "What would my higher power direct me to do?",
+        "How can I be less self-conscious and guarded?",
+        "How can I better attune myself to the abundance of life's blessings?"
+      ],
+      "hash64": "ae257ff0108daab7243bed4f426b8557d83041d8677ca3070035872db9144cea"
     },
     {
       "name": "The Moon",
@@ -758,40 +849,45 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m18.jpg",
-	  "fortune_telling": [
-                "Watch for problems at the end of the month", 
-                "Someone you know needs to howl at the moon more often", 
-                "Someone is about to change his or her mind about an important decision"
-            ], 
-            "keywords": [
-                "mystery", 
-                "fantasy", 
-                "imagination", 
-                "dreams", 
-                "uncertainty"
-            ], 
-            "meanings": {
-                "light": [
-                    "Enjoying healthy fantasies and daydreams", 
-                    "Using your imagination", 
-                    "Practicing magic or celebrating the magic of everyday life", 
-                    "Attuning yourself to the cycles of nature", 
-                    "Embracing the unknown"
-                ], 
-                "shadow": [
-                    "Becoming unable to separate fantasy from reality", 
-                    "Suffering from delusions", 
-                    "Losing your appreciation for the fantastic or magical", 
-                    "Adopting a ruthlessly logical mindset", 
-                    "Failing to appreciate life's mysteries"
-                ]
-            },
-		"Archetype" : "The Holy Feminine/The Crone",
-      "Hebrew Alphabet" : "Koph/Back of the Head/100",
-      "Numerology" : "18 = 1 + 8 = 9 (fullness, readiness, ripeness)",
-      "Elemental" : "Pisces",
-      "Mythical/Spiritual" : "Kali, the dark-skinned divine mother associated with time, the eternal night, and the female principle. Hecate, goddess of night and darkness, who, like Anubis, assists others in their travels to the underworld. ",
-	  "Questions to Ask" : ["How can I face my fears and move forward?","What helpers can serve me as guides through my personal darkness?","How can I deal with the unknown in healthy ways?"]
+      "fortune_telling": [
+        "Watch for problems at the end of the month",
+        "Someone you know needs to howl at the moon more often",
+        "Someone is about to change his or her mind about an important decision"
+      ],
+      "keywords": [
+        "mystery",
+        "fantasy",
+        "imagination",
+        "dreams",
+        "uncertainty"
+      ],
+      "meanings": {
+        "light": [
+          "Enjoying healthy fantasies and daydreams",
+          "Using your imagination",
+          "Practicing magic or celebrating the magic of everyday life",
+          "Attuning yourself to the cycles of nature",
+          "Embracing the unknown"
+        ],
+        "shadow": [
+          "Becoming unable to separate fantasy from reality",
+          "Suffering from delusions",
+          "Losing your appreciation for the fantastic or magical",
+          "Adopting a ruthlessly logical mindset",
+          "Failing to appreciate life's mysteries"
+        ]
+      },
+      "Archetype": "The Holy Feminine/The Crone",
+      "Hebrew Alphabet": "Koph/Back of the Head/100",
+      "Numerology": "18 = 1 + 8 = 9 (fullness, readiness, ripeness)",
+      "Elemental": "Pisces",
+      "Mythical/Spiritual": "Kali, the dark-skinned divine mother associated with time, the eternal night, and the female principle. Hecate, goddess of night and darkness, who, like Anubis, assists others in their travels to the underworld. ",
+      "Questions to Ask": [
+        "How can I face my fears and move forward?",
+        "What helpers can serve me as guides through my personal darkness?",
+        "How can I deal with the unknown in healthy ways?"
+      ],
+      "hash64": "6c5979adcf7a0e51cae20f960b62bef851aaa94d5961396f9f857505cbe150f7"
     },
     {
       "name": "The Sun",
@@ -799,39 +895,44 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m19.jpg",
-	  "fortune_telling": [
-                "Everything's coming up roses (or sunflowers, whatever the case may be)", 
-                "Whatever's on your mind, go for it because you can't lose today"
-            ], 
-            "keywords": [
-                "joy", 
-                "brilliance", 
-                "validation", 
-                "attention", 
-                "energy"
-            ], 
-            "meanings": {
-                "light": [
-                    "Seeing things clearly", 
-                    "Experiencing intense joy", 
-                    "Celebrating your own successes", 
-                    "Knowing you're good at what you do", 
-                    "Gaining recognition for your personal genius"
-                ], 
-                "shadow": [
-                    "Being dazzled by your own accomplishments", 
-                    "Becoming absorbed in your own self-image", 
-                    "Feeling rushed and distracted", 
-                    "Exerting yourself to the point of exhaustion", 
-                    "Overstating your abilities or misrepresenting your achievements"
-                ]
-            },
-		"Archetype" : "The Holy Masculine",
-      "Hebrew Alphabet" : "Resh/Head/200",
-      "Numerology" : "19 = 1 + 9 = 10 (completion, exhaustion) 1 + 0 = 1 (starting point, opportunity)",
-      "Elemental" : "The Sun",
-      "Mythical/Spiritual" : "God the Father. Sun gods, including Ra, Apollo, and Helios. The moment of baptism. Claiming a new faith as your own.",
-	  "Questions to Ask" : ["How can I take best advantage of the attention coming my way?","What are my highest spiritual goals?","How can I avoid being bedazzled by the energy swirling around me?"]
+      "fortune_telling": [
+        "Everything's coming up roses (or sunflowers, whatever the case may be)",
+        "Whatever's on your mind, go for it because you can't lose today"
+      ],
+      "keywords": [
+        "joy",
+        "brilliance",
+        "validation",
+        "attention",
+        "energy"
+      ],
+      "meanings": {
+        "light": [
+          "Seeing things clearly",
+          "Experiencing intense joy",
+          "Celebrating your own successes",
+          "Knowing you're good at what you do",
+          "Gaining recognition for your personal genius"
+        ],
+        "shadow": [
+          "Being dazzled by your own accomplishments",
+          "Becoming absorbed in your own self-image",
+          "Feeling rushed and distracted",
+          "Exerting yourself to the point of exhaustion",
+          "Overstating your abilities or misrepresenting your achievements"
+        ]
+      },
+      "Archetype": "The Holy Masculine",
+      "Hebrew Alphabet": "Resh/Head/200",
+      "Numerology": "19 = 1 + 9 = 10 (completion, exhaustion) 1 + 0 = 1 (starting point, opportunity)",
+      "Elemental": "The Sun",
+      "Mythical/Spiritual": "God the Father. Sun gods, including Ra, Apollo, and Helios. The moment of baptism. Claiming a new faith as your own.",
+      "Questions to Ask": [
+        "How can I take best advantage of the attention coming my way?",
+        "What are my highest spiritual goals?",
+        "How can I avoid being bedazzled by the energy swirling around me?"
+      ],
+      "hash64": "77a82d1c3f3c61ab0c20cc4898997494cd2f040187fd530546221fe9fed97e6f"
     },
     {
       "name": "Judgement",
@@ -839,41 +940,46 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m20.jpg",
-	  "fortune_telling": [
-                "An old issue you thought was over will come up again today", 
-                "Get ready for huge changes: break-ups, sudden calls from old friends, and unexpected setbacks", 
-                "God's trying to get your attention"
-            ], 
-            "keywords": [
-                "revival", 
-                "renewal", 
-                "resurrection", 
-                "evaluation", 
-                "invitation"
-            ], 
-            "meanings": {
-                "light": [
-                    "Receiving a wake-up call", 
-                    "Discovering a new purpose in life", 
-                    "Becoming totally and completely yourself", 
-                    "Receiving a well-deserved reward", 
-                    "Passing an evaluation or examination", 
-                    "Welcoming the start of a new phase of life"
-                ], 
-                "shadow": [
-                    "Being weighed in the balances and found wanting", 
-                    "Failing to measure up to a well-defined standard", 
-                    "Being caught goofing off or misbehaving", 
-                    "Failing to prepare for an examination you know is coming", 
-                    "Rejecting an opportunity to reinvent yourself"
-                ]
-            },
-		"Archetype" : "Resurrection",
-      "Hebrew Alphabet" : "Sin/Tooth/300",
-      "Numerology" : "20 = 2 + 0 = 2 (division, duality)",
-      "Elemental" : "Fire",
-      "Mythical/Spiritual" : "The resurrected Christ. The Last Judgment of Revelation. The phoenix, which rises to new life from its own ashes.",
-	  "Questions to Ask" : ["What is the main thing I need to realize about myself?","In what way might the universe be trying to get my attention?","If I were to reinvent myself, what would I become?"]
+      "fortune_telling": [
+        "An old issue you thought was over will come up again today",
+        "Get ready for huge changes: break-ups, sudden calls from old friends, and unexpected setbacks",
+        "God's trying to get your attention"
+      ],
+      "keywords": [
+        "revival",
+        "renewal",
+        "resurrection",
+        "evaluation",
+        "invitation"
+      ],
+      "meanings": {
+        "light": [
+          "Receiving a wake-up call",
+          "Discovering a new purpose in life",
+          "Becoming totally and completely yourself",
+          "Receiving a well-deserved reward",
+          "Passing an evaluation or examination",
+          "Welcoming the start of a new phase of life"
+        ],
+        "shadow": [
+          "Being weighed in the balances and found wanting",
+          "Failing to measure up to a well-defined standard",
+          "Being caught goofing off or misbehaving",
+          "Failing to prepare for an examination you know is coming",
+          "Rejecting an opportunity to reinvent yourself"
+        ]
+      },
+      "Archetype": "Resurrection",
+      "Hebrew Alphabet": "Sin/Tooth/300",
+      "Numerology": "20 = 2 + 0 = 2 (division, duality)",
+      "Elemental": "Fire",
+      "Mythical/Spiritual": "The resurrected Christ. The Last Judgment of Revelation. The phoenix, which rises to new life from its own ashes.",
+      "Questions to Ask": [
+        "What is the main thing I need to realize about myself?",
+        "In what way might the universe be trying to get my attention?",
+        "If I were to reinvent myself, what would I become?"
+      ],
+      "hash64": "18d3597ca7321b870805999b94b4303977f1a29cdfe6eabea08163a478156d73"
     },
     {
       "name": "The World",
@@ -881,40 +987,45 @@
       "arcana": "Major Arcana",
       "suit": "Trump",
       "img": "m21.jpg",
-	  "fortune_telling": [
-                "Winning the lottery", 
-                "Getting your heart's desire", 
-                "Having everything you ever imagined having"
-            ], 
-            "keywords": [
-                "wholeness", 
-                "integration", 
-                "totality", 
-                "completeness", 
-                "fullness"
-            ], 
-            "meanings": {
-                "light": [
-                    "Having it all", 
-                    "Knowing and loving yourself as completely as possible", 
-                    "Seeing the interconnection of all things and people", 
-                    "Enhancing your perspective", 
-                    "Living life to its fullest", 
-                    "Understanding the meaning of life"
-                ], 
-                "shadow": [
-                    "Allowing greed and envy to prevent you from enjoying what you do possess", 
-                    "Failing to see the larger design in ordinary events", 
-                    "Believing that everything that exists can be touched, counted, or measured", 
-                    "Failing to see the divine reflected in those around you"
-                ]
-            },
-		"Archetype" : "Enlightenment",
-      "Hebrew Alphabet" : "Tau/Cross/400",
-      "Numerology" : "21 = 2 + 1 = 3 (expression, result)",
-      "Elemental" : "Saturn",
-      "Mythical/Spiritual" : "The ascended Christ. The Buddha attaining enlightenment. The alpha and the omega. The completion of the alchemist's great work.",
-	  "Questions to Ask" : ["For me, what would having it all mean?","How aware am I of my own connectedness to the world around me?","What keeps me from having it all right now, today?"]
+      "fortune_telling": [
+        "Winning the lottery",
+        "Getting your heart's desire",
+        "Having everything you ever imagined having"
+      ],
+      "keywords": [
+        "wholeness",
+        "integration",
+        "totality",
+        "completeness",
+        "fullness"
+      ],
+      "meanings": {
+        "light": [
+          "Having it all",
+          "Knowing and loving yourself as completely as possible",
+          "Seeing the interconnection of all things and people",
+          "Enhancing your perspective",
+          "Living life to its fullest",
+          "Understanding the meaning of life"
+        ],
+        "shadow": [
+          "Allowing greed and envy to prevent you from enjoying what you do possess",
+          "Failing to see the larger design in ordinary events",
+          "Believing that everything that exists can be touched, counted, or measured",
+          "Failing to see the divine reflected in those around you"
+        ]
+      },
+      "Archetype": "Enlightenment",
+      "Hebrew Alphabet": "Tau/Cross/400",
+      "Numerology": "21 = 2 + 1 = 3 (expression, result)",
+      "Elemental": "Saturn",
+      "Mythical/Spiritual": "The ascended Christ. The Buddha attaining enlightenment. The alpha and the omega. The completion of the alchemist's great work.",
+      "Questions to Ask": [
+        "For me, what would having it all mean?",
+        "How aware am I of my own connectedness to the world around me?",
+        "What keeps me from having it all right now, today?"
+      ],
+      "hash64": "7ab291335a165271918d7372ebb4bfeed4a84e0be7f000d52be53a47fb3e5a09"
     },
     {
       "name": "Ace of Cups",
@@ -922,39 +1033,44 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c01.jpg",
-	  "fortune_telling": [
-                "Romance is in the cards",
-                "A new relationship or marriage is just around the corner", 
-                "Prayers are answered"
-            ], 
-            "keywords": [
-                "intuition", 
-                "spirituality", 
-                "affection", 
-                "motivation"
-            ], 
-            "meanings": {
-                "light": [
-                    "Trusting your feelings", 
-                    "Opening yourself to spirit", 
-                    "Accepting and returning affection", 
-                    "Getting in touch with what motivates you", 
-                    "Taking advantage of an opportunity to express love to others", 
-                    "Listening to the still, small voice"
-                ], 
-                "shadow": [
-                    "Hiding your feelings", 
-                    "Spurning an opportunity to love or be loved", 
-                    "Numbing yourself to spiritual yearnings", 
-                    "Rejecting the counsel of your heart", 
-                    "Becoming a puppet of your own emotions", 
-                    "Indulging in hysteria or obsession"
-                ]
-            },
-		"Numerology" : "1 (The Origin: the starting point, the seed, opportunity)",
-      "Astrology" : "Cancer, Scorpio, Pisces",
-      "Affirmation" : "\"I listen to the counsel of my heart.\"",
-	  "Questions to Ask" : ["What am I feeling right now?","How would I go about opening myself to spiritual guidance?","What motivates me the most - pleasure or pain? Why?"]
+      "fortune_telling": [
+        "Romance is in the cards",
+        "A new relationship or marriage is just around the corner",
+        "Prayers are answered"
+      ],
+      "keywords": [
+        "intuition",
+        "spirituality",
+        "affection",
+        "motivation"
+      ],
+      "meanings": {
+        "light": [
+          "Trusting your feelings",
+          "Opening yourself to spirit",
+          "Accepting and returning affection",
+          "Getting in touch with what motivates you",
+          "Taking advantage of an opportunity to express love to others",
+          "Listening to the still, small voice"
+        ],
+        "shadow": [
+          "Hiding your feelings",
+          "Spurning an opportunity to love or be loved",
+          "Numbing yourself to spiritual yearnings",
+          "Rejecting the counsel of your heart",
+          "Becoming a puppet of your own emotions",
+          "Indulging in hysteria or obsession"
+        ]
+      },
+      "Numerology": "1 (The Origin: the starting point, the seed, opportunity)",
+      "Astrology": "Cancer, Scorpio, Pisces",
+      "Affirmation": "\"I listen to the counsel of my heart.\"",
+      "Questions to Ask": [
+        "What am I feeling right now?",
+        "How would I go about opening myself to spiritual guidance?",
+        "What motivates me the most - pleasure or pain? Why?"
+      ],
+      "hash64": "20b8781d3ed79dafbf3a53600d95a63d87f484170dbbe4a79d359bfb4694ecbf"
     },
     {
       "name": "Two of Cups",
@@ -962,40 +1078,44 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c02.jpg",
-	  "fortune_telling": [
-                "Someone has a secret crush on you", 
-                "Relationships should be mutual; get rid of a leech"
-            ], 
-            "keywords": [
-                "union", 
-                "attraction", 
-                "combination", 
-                "affection"
-            ], 
-            "meanings": {
-                "light": [
-                    "Being drawn to someone", 
-                    "Longing for someone or something", 
-                    "Acting on your desires", 
-                    "Discovering a feeling is mutual", 
-                    "Doing what makes you feel good", 
-                    "Merging", 
-                    "Healing broken ties", 
-                    "Admitting two people feel differently about each other and moving on"
-                ], 
-                "shadow": [
-                    "Burning bridges", 
-                    "Becoming caught up in unhealthy codependency", 
-                    "Shutting out anyone but your chosen few", 
-                    "Obsessing on someone who does not return your affections", 
-                    "Despairing over finding \"The One\"",
-                    "Deceiving yourself about your true orientation"
-                ]
-            },
-		"Numerology" : "2 (The Other: duality, division, debate)",
-      "Astrology" : "Venus in Cancer",
-      "Affirmation" : "\"I am attuned to what my heart truly desires.\"",
-	   "Questions to Ask" : ["How can I make sure that what I'm feeling is mutual?\",\"When was the last time I felt \"in love\" with someone or something?","What do you need in order to feel emotionally stable?"]
+      "fortune_telling": [
+        "Someone has a secret crush on you",
+        "Relationships should be mutual; get rid of a leech"
+      ],
+      "keywords": [
+        "union",
+        "attraction",
+        "combination",
+        "affection"
+      ],
+      "meanings": {
+        "light": [
+          "Being drawn to someone",
+          "Longing for someone or something",
+          "Acting on your desires",
+          "Discovering a feeling is mutual",
+          "Doing what makes you feel good",
+          "Merging",
+          "Healing broken ties",
+          "Admitting two people feel differently about each other and moving on"
+        ],
+        "shadow": [
+          "Burning bridges",
+          "Becoming caught up in unhealthy codependency",
+          "Shutting out anyone but your chosen few",
+          "Obsessing on someone who does not return your affections",
+          "Despairing over finding \"The One\"",
+          "Deceiving yourself about your true orientation"
+        ]
+      },
+      "Numerology": "2 (The Other: duality, division, debate)",
+      "Astrology": "Venus in Cancer",
+      "Affirmation": "\"I am attuned to what my heart truly desires.\"",
+      "Questions to Ask": [
+        "How can I make sure that what I'm feeling is mutual?\",\"When was the last time I felt \"in love\" with someone or something?",
+        "What do you need in order to feel emotionally stable?"
+      ],
+      "hash64": "b312a559bfdc267506285cb3137a3c56308539534b0f828a1a4957a76d1367b7"
     },
     {
       "name": "Three of Cups",
@@ -1003,35 +1123,40 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c03.jpg",
-	  "fortune_telling": [
-                "Unconventional romance is coming your way: a love affair with someone you've always dismissed"
-            ], 
-            "keywords": [
-                "celebration", 
-                "expression", 
-                "community", 
-                "friendliness"
-            ], 
-            "meanings": {
-                "light": [
-                    "Celebrating your feelings or connections with others", 
-                    "Expressing joy through song, dance, or physical affection", 
-                    "Working together with others who share your feelings", 
-                    "Performing acts of service as a way of saying, \"I love you\"",
-                    "Embracing unconventional romantic arrangements"
-                ], 
-                "shadow": [
-                    "Mistaking giddiness for true affection", 
-                    "Being dominated by manic emotions", 
-                    "Expecting everyone to always feel the same way you do", 
-                    "Demanding unreasonable support from friends or family", 
-                    "Partying to a dangerous or unhealthy extent"
-                ]
-            },
-		"Numerology" : "3 (The Result: expression, productivity, output)",
-      "Astrology" : "Mercury in Cancer",
-      "Affirmation" : "\"I allow my actions to reflect my true emotions.\"",
-	  "Questions to Ask" : ["What's worth celebrating in my life?","How can I demonstrate my feelings in appropriate ways?","What can I do to show my partner how I really feel?"]
+      "fortune_telling": [
+        "Unconventional romance is coming your way: a love affair with someone you've always dismissed"
+      ],
+      "keywords": [
+        "celebration",
+        "expression",
+        "community",
+        "friendliness"
+      ],
+      "meanings": {
+        "light": [
+          "Celebrating your feelings or connections with others",
+          "Expressing joy through song, dance, or physical affection",
+          "Working together with others who share your feelings",
+          "Performing acts of service as a way of saying, \"I love you\"",
+          "Embracing unconventional romantic arrangements"
+        ],
+        "shadow": [
+          "Mistaking giddiness for true affection",
+          "Being dominated by manic emotions",
+          "Expecting everyone to always feel the same way you do",
+          "Demanding unreasonable support from friends or family",
+          "Partying to a dangerous or unhealthy extent"
+        ]
+      },
+      "Numerology": "3 (The Result: expression, productivity, output)",
+      "Astrology": "Mercury in Cancer",
+      "Affirmation": "\"I allow my actions to reflect my true emotions.\"",
+      "Questions to Ask": [
+        "What's worth celebrating in my life?",
+        "How can I demonstrate my feelings in appropriate ways?",
+        "What can I do to show my partner how I really feel?"
+      ],
+      "hash64": "96c4e2c8275d503097caf8dfd3a2b33fda2d1171a779dc39eb59fd55aea3bb7d"
     },
     {
       "name": "Four of Cups",
@@ -1039,38 +1164,43 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c04.jpg",
-	  "fortune_telling": [
-                "A lover is getting restless", 
-                "Find out what he or she needs, or new opportunities may lure your partner away"
-            ], 
-            "keywords": [
-                "boredom", 
-                "listlessness", 
-                "lethargy", 
-                "stability", 
-                "ingratitude"
-            ], 
-            "meanings": {
-                "light": [
-                    "Maintaining your emotional stability", 
-                    "Refusing to give in to overwhelming emotions", 
-                    "Appreciating what you have and refusing to take it for granted", 
-                    "Seeing the value of long-term commitments"
-                ], 
-                "shadow": [
-                    "Being bored", 
-                    "Daydreaming at the expense of your work", 
-                    "Refusing to be engaged by opportunity", 
-                    "Taking people and relationships for granted", 
-                    "Ignoring romantic or spiritual opportunities", 
-                    "Spurning inspiration", 
-                    "Feeling everything should stay \"just like it is\""
-                ]
-            },
-		 "Numerology" : "4 (The Status Quo: stability, equality, persistence)",
-      "Astrology" : "Moon in Cancer",
-      "Affirmation" : "\"I appreciate what I've been given.\"",
-	  "Questions to Ask" : ["How can I use this \"downtime\" to my best advantage?","How can I show my partner that I don't take him or her for granted?","To what extent is my mood blinding me to new opportunities?"]
+      "fortune_telling": [
+        "A lover is getting restless",
+        "Find out what he or she needs, or new opportunities may lure your partner away"
+      ],
+      "keywords": [
+        "boredom",
+        "listlessness",
+        "lethargy",
+        "stability",
+        "ingratitude"
+      ],
+      "meanings": {
+        "light": [
+          "Maintaining your emotional stability",
+          "Refusing to give in to overwhelming emotions",
+          "Appreciating what you have and refusing to take it for granted",
+          "Seeing the value of long-term commitments"
+        ],
+        "shadow": [
+          "Being bored",
+          "Daydreaming at the expense of your work",
+          "Refusing to be engaged by opportunity",
+          "Taking people and relationships for granted",
+          "Ignoring romantic or spiritual opportunities",
+          "Spurning inspiration",
+          "Feeling everything should stay \"just like it is\""
+        ]
+      },
+      "Numerology": "4 (The Status Quo: stability, equality, persistence)",
+      "Astrology": "Moon in Cancer",
+      "Affirmation": "\"I appreciate what I've been given.\"",
+      "Questions to Ask": [
+        "How can I use this \"downtime\" to my best advantage?",
+        "How can I show my partner that I don't take him or her for granted?",
+        "To what extent is my mood blinding me to new opportunities?"
+      ],
+      "hash64": "a8a091a93e34d77e14e665c683f32c512682fcaee268d8decabec83ea0fb334e"
     },
     {
       "name": "Five of Cups",
@@ -1078,42 +1208,47 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c05.jpg",
-	  "fortune_telling": [
-                "A breakup looms", 
-                "Don't cry over spilt milk", 
-                "Take your lumps and get back in the saddle"
-            ], 
-            "keywords": [
-                "loss", 
-                "despair", 
-                "re-evaluation", 
-                "regret", 
-                "uncertainty", 
-                "repentance"
-            ], 
-            "meanings": {
-                "light": [
-                    "Acknowledging loss and moving on", 
-                    "Focusing on how the glass remains \"half-full\"",
-                    "Finding the silver lining in a dark cloud", 
-                    "Recognizing that loss is a natural part of life", 
-                    "Embracing healthy grief", 
-                    "Learning lessons from harsh consequences"
-                ], 
-                "shadow": [
-                    "Wallowing in unhealthy grief or self-pity", 
-                    "Refusing to move on and let go", 
-                    "Clinging to the past", 
-                    "Obsessing on past lives and past loves", 
-                    "Failing to live in the present", 
-                    "Beating yourself up over past mistakes", 
-                    "Allowing fear of failure to limit your efforts"
-                ]
-            },
-		"Numerology" : "5 (The Catalyst: instability, resistance, confrontation)",
-      "Astrology" : "Mars in Scorpio",
-      "Affirmation" : "\"I learn from my losses and move on.\"",
-	  "Questions to Ask" : ["How do I tend to deal with loss?","What life lesson might I be learning now?","How can I shift my attention from the past to the future?"]
+      "fortune_telling": [
+        "A breakup looms",
+        "Don't cry over spilt milk",
+        "Take your lumps and get back in the saddle"
+      ],
+      "keywords": [
+        "loss",
+        "despair",
+        "re-evaluation",
+        "regret",
+        "uncertainty",
+        "repentance"
+      ],
+      "meanings": {
+        "light": [
+          "Acknowledging loss and moving on",
+          "Focusing on how the glass remains \"half-full\"",
+          "Finding the silver lining in a dark cloud",
+          "Recognizing that loss is a natural part of life",
+          "Embracing healthy grief",
+          "Learning lessons from harsh consequences"
+        ],
+        "shadow": [
+          "Wallowing in unhealthy grief or self-pity",
+          "Refusing to move on and let go",
+          "Clinging to the past",
+          "Obsessing on past lives and past loves",
+          "Failing to live in the present",
+          "Beating yourself up over past mistakes",
+          "Allowing fear of failure to limit your efforts"
+        ]
+      },
+      "Numerology": "5 (The Catalyst: instability, resistance, confrontation)",
+      "Astrology": "Mars in Scorpio",
+      "Affirmation": "\"I learn from my losses and move on.\"",
+      "Questions to Ask": [
+        "How do I tend to deal with loss?",
+        "What life lesson might I be learning now?",
+        "How can I shift my attention from the past to the future?"
+      ],
+      "hash64": "1b6de66e7b5a6c6e8beb2457d6ee287a90aa4bf1b2f184347259c1d4bebe3a73"
     },
     {
       "name": "Six of Cups",
@@ -1121,38 +1256,43 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c06.jpg",
-	  "fortune_telling": [
-                "A stingy spirit is strangling your enjoyment of life", 
-                "Loosen up and think of others for once, why don't you?"
-            ], 
-            "keywords": [
-                "charity", 
-                "sharing", 
-                "sacrifice", 
-                "cooperation", 
-                "fairness"
-            ], 
-            "meanings": {
-                "light": [
-                    "Donating your time and talents to others", 
-                    "Taking satisfaction in knowing how your efforts will aid others", 
-                    "Creating a \"win-win\" scenario", 
-                    "Giving even when you know repayment is not possible", 
-                    "Being motivated to do a good deed"
-                ], 
-                "shadow": [
-                    "Linking your sense of self-worth to the appraisals of others", 
-                    "Striving to appear more needy than you really are", 
-                    "Taking undeserved or unmerited charity", 
-                    "Bragging about your charitable efforts", 
-                    "Profiteering in times of distress", 
-                    "Refusing to share a burden"
-                ]
-            },
-		"Numerology" : "6 (The Adjustment: cooperation, collaboration, interaction)",
-      "Astrology" : "Sun in Scorpio",
-      "Affirmation" : "\"I freely give myself to others, expecting nothing in return.\"",
-	   "Questions to Ask" : ["What gifts do I possess? How freely do I give them?","How can I practice unconditional giving?","How would things change if I became a more charitable person?"]
+      "fortune_telling": [
+        "A stingy spirit is strangling your enjoyment of life",
+        "Loosen up and think of others for once, why don't you?"
+      ],
+      "keywords": [
+        "charity",
+        "sharing",
+        "sacrifice",
+        "cooperation",
+        "fairness"
+      ],
+      "meanings": {
+        "light": [
+          "Donating your time and talents to others",
+          "Taking satisfaction in knowing how your efforts will aid others",
+          "Creating a \"win-win\" scenario",
+          "Giving even when you know repayment is not possible",
+          "Being motivated to do a good deed"
+        ],
+        "shadow": [
+          "Linking your sense of self-worth to the appraisals of others",
+          "Striving to appear more needy than you really are",
+          "Taking undeserved or unmerited charity",
+          "Bragging about your charitable efforts",
+          "Profiteering in times of distress",
+          "Refusing to share a burden"
+        ]
+      },
+      "Numerology": "6 (The Adjustment: cooperation, collaboration, interaction)",
+      "Astrology": "Sun in Scorpio",
+      "Affirmation": "\"I freely give myself to others, expecting nothing in return.\"",
+      "Questions to Ask": [
+        "What gifts do I possess? How freely do I give them?",
+        "How can I practice unconditional giving?",
+        "How would things change if I became a more charitable person?"
+      ],
+      "hash64": "240fbcc6b591308357846aa3b6df611e1fdf28738918a0d0e66b549a42c77b9c"
     },
     {
       "name": "Seven of Cups",
@@ -1160,36 +1300,41 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c07.jpg",
-	  "fortune_telling": [
-                "You're being fed a line", 
-                "Rather than be dazzled by fancy words and promises, demand something real"
-            ], 
-            "keywords": [
-                "imagination", 
-                "dreams", 
-                "illusions", 
-                "goals"
-            ], 
-            "meanings": {
-                "light": [
-                    "Motivating yourself with images of future success", 
-                    "Using visualization to encourage progress", 
-                    "Taking an imaginative or creative approach to problem solving", 
-                    "Making dreams come true", 
-                    "Gleaning insight from personal visions"
-                ], 
-                "shadow": [
-                    "Obsessing on imaginary fears or uncertain consequences", 
-                    "Giving in to emotional or political terrorism", 
-                    "Spending more time dreaming than working", 
-                    "Failing to envision the possible repercussions of your choices", 
-                    "Being controlled by fear"
-                ]
-            },
-		"Numerology" : "7 (The Motive: imagination, inner work, psychology)",
-      "Astrology" : "Venus in Scorpio",
-      "Affirmation" : "\"I use inner vision as a tool for growth.\"",
-	  "Questions to Ask" : ["What do you want most? What do you fear most? How are these related?","How is your imagination working for you? Against you?","How might a clearer personal vision help you choose a single cup from the many available?"]
+      "fortune_telling": [
+        "You're being fed a line",
+        "Rather than be dazzled by fancy words and promises, demand something real"
+      ],
+      "keywords": [
+        "imagination",
+        "dreams",
+        "illusions",
+        "goals"
+      ],
+      "meanings": {
+        "light": [
+          "Motivating yourself with images of future success",
+          "Using visualization to encourage progress",
+          "Taking an imaginative or creative approach to problem solving",
+          "Making dreams come true",
+          "Gleaning insight from personal visions"
+        ],
+        "shadow": [
+          "Obsessing on imaginary fears or uncertain consequences",
+          "Giving in to emotional or political terrorism",
+          "Spending more time dreaming than working",
+          "Failing to envision the possible repercussions of your choices",
+          "Being controlled by fear"
+        ]
+      },
+      "Numerology": "7 (The Motive: imagination, inner work, psychology)",
+      "Astrology": "Venus in Scorpio",
+      "Affirmation": "\"I use inner vision as a tool for growth.\"",
+      "Questions to Ask": [
+        "What do you want most? What do you fear most? How are these related?",
+        "How is your imagination working for you? Against you?",
+        "How might a clearer personal vision help you choose a single cup from the many available?"
+      ],
+      "hash64": "28b86565c97a366c3c61616d6bc5114b99a954388e0447e78990407075b99938"
     },
     {
       "name": "Eight of Cups",
@@ -1197,42 +1342,47 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c08.jpg",
-	  "fortune_telling": [
-                "Someone's \"stepping out\" on you, now or in the near future", 
-                "Maybe it's time to quit talking about the problem and just move on"
-            ], 
-            "keywords": [
-                "longing", 
-                "dissatisfaction", 
-                "quest", 
-                "departure", 
-                "withdrawal"
-            ], 
-            "meanings": {
-                "light": [
-                    "Wanting something better", 
-                    "Blazing your own trail", 
-                    "Realizing there must be more to life", 
-                    "Leaving an unhealthy situation behind", 
-                    "Starting your own business", 
-                    "Going on a retreat", 
-                    "Seeking the \"still, small voice\""
-                ], 
-                "shadow": [
-                    "Being implacable", 
-                    "Finding fault", 
-                    "Nitpicking", 
-                    "Refusing to settle down", 
-                    "Running away from problems or confrontations", 
-                    "Saying, \"It's my way or the highway!\"",
-                    "Harping on past mistakes and disappointments", 
-                    "Threatening to quit as a strategy to get your way"
-                ]
-            },
-		"Numerology" : "8 (The Action: movement, outer work, swiftness)",
-      "Astrology" : "Saturn in Pisces",
-      "Affirmation" : "\"I am always open to opportunities for growth.\"",
-	  "Questions to Ask" : ["What do I need to leave behind once and for all?","If I left in search of \"more,\" what would I be looking for, exactly?","How might a retreat enhance my perspective?"]
+      "fortune_telling": [
+        "Someone's \"stepping out\" on you, now or in the near future",
+        "Maybe it's time to quit talking about the problem and just move on"
+      ],
+      "keywords": [
+        "longing",
+        "dissatisfaction",
+        "quest",
+        "departure",
+        "withdrawal"
+      ],
+      "meanings": {
+        "light": [
+          "Wanting something better",
+          "Blazing your own trail",
+          "Realizing there must be more to life",
+          "Leaving an unhealthy situation behind",
+          "Starting your own business",
+          "Going on a retreat",
+          "Seeking the \"still, small voice\""
+        ],
+        "shadow": [
+          "Being implacable",
+          "Finding fault",
+          "Nitpicking",
+          "Refusing to settle down",
+          "Running away from problems or confrontations",
+          "Saying, \"It's my way or the highway!\"",
+          "Harping on past mistakes and disappointments",
+          "Threatening to quit as a strategy to get your way"
+        ]
+      },
+      "Numerology": "8 (The Action: movement, outer work, swiftness)",
+      "Astrology": "Saturn in Pisces",
+      "Affirmation": "\"I am always open to opportunities for growth.\"",
+      "Questions to Ask": [
+        "What do I need to leave behind once and for all?",
+        "If I left in search of \"more,\" what would I be looking for, exactly?",
+        "How might a retreat enhance my perspective?"
+      ],
+      "hash64": "3b3f1b1a5c317225f455cc8892337c378b639d3a05bd18fd04f6108c261d697a"
     },
     {
       "name": "Nine of Cups",
@@ -1240,38 +1390,43 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c09.jpg",
-	  "fortune_telling": [
-                "Whatever you want, you'll get it"
-            ], 
-            "keywords": [
-                "satisfaction", 
-                "sensuality", 
-                "luxury", 
-                "pleasure"
-            ], 
-            "meanings": {
-                "light": [
-                    "Being delighted with your own achievements", 
-                    "Recognizing your own talents and abilities", 
-                    "Reveling in the good things life has to offer", 
-                    "Indulging yourself", 
-                    "Relaxing and unwinding", 
-                    "Having everything you need in order to feel complete"
-                ], 
-                "shadow": [
-                    "Being smug", 
-                    "Satisfying yourself at the expense of others", 
-                    "Being selfish", 
-                    "Over-indulging", 
-                    "Avoiding work that needs to be done", 
-                    "Claiming achievements or skills you do not possess", 
-                    "Never being satisfied, no matter how much you have"
-                ]
-            },
-		"Numerology" : "9 (The Completion: fullness, readiness, ripeness)",
-      "Astrology" : "Jupiter in Pisces",
-      "Affirmation" : "\"I have everything I need to be happy.\"",
-	   "Questions to Ask" : ["What is true happiness?","If I could have anything, what would I have?","What is my attitude toward luxury? Do I deserve it?"]
+      "fortune_telling": [
+        "Whatever you want, you'll get it"
+      ],
+      "keywords": [
+        "satisfaction",
+        "sensuality",
+        "luxury",
+        "pleasure"
+      ],
+      "meanings": {
+        "light": [
+          "Being delighted with your own achievements",
+          "Recognizing your own talents and abilities",
+          "Reveling in the good things life has to offer",
+          "Indulging yourself",
+          "Relaxing and unwinding",
+          "Having everything you need in order to feel complete"
+        ],
+        "shadow": [
+          "Being smug",
+          "Satisfying yourself at the expense of others",
+          "Being selfish",
+          "Over-indulging",
+          "Avoiding work that needs to be done",
+          "Claiming achievements or skills you do not possess",
+          "Never being satisfied, no matter how much you have"
+        ]
+      },
+      "Numerology": "9 (The Completion: fullness, readiness, ripeness)",
+      "Astrology": "Jupiter in Pisces",
+      "Affirmation": "\"I have everything I need to be happy.\"",
+      "Questions to Ask": [
+        "What is true happiness?",
+        "If I could have anything, what would I have?",
+        "What is my attitude toward luxury? Do I deserve it?"
+      ],
+      "hash64": "1ead24574636d9f1fa928217a893b578aebf69cd7d84d373c999fc5a582a8d76"
     },
     {
       "name": "Ten of Cups",
@@ -1279,35 +1434,40 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c10.jpg",
-	  "fortune_telling": [
-                "Marriage and family are in the cards", 
-                "Expect a friendship to blossom into a romance"
-            ], 
-            "keywords": [
-                "joy", 
-                "fulfillment", 
-                "overwhelming emotion", 
-                "giddiness"
-            ], 
-            "meanings": {
-                "light": [
-                    "Having more than you ever dreamed", 
-                    "Being deeply thankful for all you've been given", 
-                    "Recognizing the Hand of God in the gifts the Universe brings your way", 
-                    "Experiencing transcendent joy", 
-                    "Achieving domestic bliss"
-                ], 
-                "shadow": [
-                    "Comparing your achievements or relationships to unrealistic fantasy standards", 
-                    "Experiencing emotions so intense they blunt your ability to cope with reality", 
-                    "Feeling overwhelmed", 
-                    "Envying the achievements and happiness of others"
-                ]
-            },
-		"Numerology" : "10 (The End: finality, completion, exhaustion)",
-      "Astrology" : "Mars in Pisces",
-      "Affirmation" : "\"I take time to appreciate what I've been given.\"",
-	  "Questions to Ask" : ["Who gets to define what \"joy\" consists of?","What course of action is available when you feel overwhelmed?","How might vows or promises play a role in achieving a greater level of joy in your life?"]
+      "fortune_telling": [
+        "Marriage and family are in the cards",
+        "Expect a friendship to blossom into a romance"
+      ],
+      "keywords": [
+        "joy",
+        "fulfillment",
+        "overwhelming emotion",
+        "giddiness"
+      ],
+      "meanings": {
+        "light": [
+          "Having more than you ever dreamed",
+          "Being deeply thankful for all you've been given",
+          "Recognizing the Hand of God in the gifts the Universe brings your way",
+          "Experiencing transcendent joy",
+          "Achieving domestic bliss"
+        ],
+        "shadow": [
+          "Comparing your achievements or relationships to unrealistic fantasy standards",
+          "Experiencing emotions so intense they blunt your ability to cope with reality",
+          "Feeling overwhelmed",
+          "Envying the achievements and happiness of others"
+        ]
+      },
+      "Numerology": "10 (The End: finality, completion, exhaustion)",
+      "Astrology": "Mars in Pisces",
+      "Affirmation": "\"I take time to appreciate what I've been given.\"",
+      "Questions to Ask": [
+        "Who gets to define what \"joy\" consists of?",
+        "What course of action is available when you feel overwhelmed?",
+        "How might vows or promises play a role in achieving a greater level of joy in your life?"
+      ],
+      "hash64": "ce66d6c3d48b52a9409cc8aa425018ff06e2481308fbadb9224a2b868affdbe1"
     },
     {
       "name": "Page of Cups",
@@ -1315,37 +1475,42 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c11.jpg",
-	  "fortune_telling": [
-                "This card represents a young man or woman with a watery, dreamy demeanor, likely born a Libra, Scorpio, or Sagittarius, who wants to start a new relationship with you"
-            ], 
-            "keywords": [
-                "enthusiasm", 
-                "first impressions", 
-                "romanticism", 
-                "superficiality"
-            ], 
-            "meanings": {
-                "light": [
-                    "Showing your emotions freely", 
-                    "Throwing yourself into romance", 
-                    "Nursing a secret crush", 
-                    "Indulging in romantic fantasy", 
-                    "Starting a new relationship", 
-                    "Recalling your first love", 
-                    "Experiencing love for the first time", 
-                    "Converting to a new religion"
-                ], 
-                "shadow": [
-                    "Mistaking a crush for true love", 
-                    "Reading romantic intention into innocent action", 
-                    "Frantically trying to impress others", 
-                    "Indulging in overly-sweet sentimentality", 
-                    "Pretending to more romantic or spiritual experience than you possess"
-                ]
-            },
-		 "Elemental" : "Earth of Water.",
-      "Affirmation" : "\"I am ready to embrace love and Spirit.\"",
-	  "Questions to Ask" : ["How worried are you that others will see you as foolish or inexperienced?","To what extent can you be honest about your lack of experience in love and faith?","How can you maintain enthusiasm over time?"]
+      "fortune_telling": [
+        "This card represents a young man or woman with a watery, dreamy demeanor, likely born a Libra, Scorpio, or Sagittarius, who wants to start a new relationship with you"
+      ],
+      "keywords": [
+        "enthusiasm",
+        "first impressions",
+        "romanticism",
+        "superficiality"
+      ],
+      "meanings": {
+        "light": [
+          "Showing your emotions freely",
+          "Throwing yourself into romance",
+          "Nursing a secret crush",
+          "Indulging in romantic fantasy",
+          "Starting a new relationship",
+          "Recalling your first love",
+          "Experiencing love for the first time",
+          "Converting to a new religion"
+        ],
+        "shadow": [
+          "Mistaking a crush for true love",
+          "Reading romantic intention into innocent action",
+          "Frantically trying to impress others",
+          "Indulging in overly-sweet sentimentality",
+          "Pretending to more romantic or spiritual experience than you possess"
+        ]
+      },
+      "Elemental": "Earth of Water.",
+      "Affirmation": "\"I am ready to embrace love and Spirit.\"",
+      "Questions to Ask": [
+        "How worried are you that others will see you as foolish or inexperienced?",
+        "To what extent can you be honest about your lack of experience in love and faith?",
+        "How can you maintain enthusiasm over time?"
+      ],
+      "hash64": "0a1a4ca5f201a7e0920ad873cbbcae3e1dfb84d7231279db5a81fdf3a441ce02"
     },
     {
       "name": "Knight of Cups",
@@ -1353,35 +1518,40 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c12.jpg",
-	  "fortune_telling": [
-                "This card represents a man with an emotional, sensitive personality, likely born between October 13th and November 11th, who wants you to rally around his latest passionate cause"
-            ], 
-            "keywords": [
-                "fervor", 
-                "zeal", 
-                "moodiness", 
-                "illumination"
-            ], 
-            "meanings": {
-                "light": [
-                    "Being deeply committed to a cause", 
-                    "Giving in to strong emotions, from excitement to depression", 
-                    "Acting on intuition alone", 
-                    "Solving problems intuitively", 
-                    "Believing in and basing decisions on ideals instead of realities", 
-                    "Bringing intuition or passion to the table"
-                ], 
-                "shadow": [
-                    "Becoming a fanatic", 
-                    "Rejecting information that suggests your intuitions are misguided", 
-                    "Allowing your emotions to control you", 
-                    "Giving in to jealousy, confrontation, and peer pressure", 
-                    "Hiding or ignoring intuitive insights"
-                ]
-            },
-		"Elemental" : "Air of Water.",
-      "Affirmation" : "\"I translate my passions into actions.\"",
-	   "Questions to Ask" : ["How prone to emotional extremes are you?","What's the difference in driving passion and blind zeal?","How can you inspire others without inciting a riot?"]
+      "fortune_telling": [
+        "This card represents a man with an emotional, sensitive personality, likely born between October 13th and November 11th, who wants you to rally around his latest passionate cause"
+      ],
+      "keywords": [
+        "fervor",
+        "zeal",
+        "moodiness",
+        "illumination"
+      ],
+      "meanings": {
+        "light": [
+          "Being deeply committed to a cause",
+          "Giving in to strong emotions, from excitement to depression",
+          "Acting on intuition alone",
+          "Solving problems intuitively",
+          "Believing in and basing decisions on ideals instead of realities",
+          "Bringing intuition or passion to the table"
+        ],
+        "shadow": [
+          "Becoming a fanatic",
+          "Rejecting information that suggests your intuitions are misguided",
+          "Allowing your emotions to control you",
+          "Giving in to jealousy, confrontation, and peer pressure",
+          "Hiding or ignoring intuitive insights"
+        ]
+      },
+      "Elemental": "Air of Water.",
+      "Affirmation": "\"I translate my passions into actions.\"",
+      "Questions to Ask": [
+        "How prone to emotional extremes are you?",
+        "What's the difference in driving passion and blind zeal?",
+        "How can you inspire others without inciting a riot?"
+      ],
+      "hash64": "34ffa7c16be5f6a3b1501da73c97aa3586c3742902504c3fd4d4ecdd040933f4"
     },
     {
       "name": "Queen of Cups",
@@ -1389,35 +1559,40 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c13.jpg",
-	  "fortune_telling": [
-                "This card represents a woman with an emotional, deeply spiritual nature, likely born between June 11th and July 11th, who uses emotional and spiritual appeals to sway others to her point of view"
-            ], 
-            "keywords": [
-                "insightfulness", 
-                "spirituality", 
-                "compassion", 
-                "empathy", 
-                "instinct"
-            ], 
-            "meanings": {
-                "light": [
-                    "Allowing yourself to be moved by the plight of others", 
-                    "Feeling strong emotions", 
-                    "Possessing unusual sympathy or empathy", 
-                    "Trusting your feelings to guide you", 
-                    "Calling on psychic abilities", 
-                    "Achieving unity with Spirit"
-                ], 
-                "shadow": [
-                    "Becoming so caught up in matters of Spirit, you become detached from the world", 
-                    "Allowing empathy to disable you (instead of inspire action)", 
-                    "Using psychic abilities to wield covert influence", 
-                    "Wallowing in emotionalism, sentiment, or self-pity"
-                ]
-            },
-		"Elemental" : "Water of Water.",
-      "Affirmation" : "\"I choose to be enabled, not disabled, by my strong emotions.\"",
-	  "Questions to Ask" : ["How do I handle strong emotions?","To what extent am I a victim of my own feelings?","How can I move from reflection to action?"]
+      "fortune_telling": [
+        "This card represents a woman with an emotional, deeply spiritual nature, likely born between June 11th and July 11th, who uses emotional and spiritual appeals to sway others to her point of view"
+      ],
+      "keywords": [
+        "insightfulness",
+        "spirituality",
+        "compassion",
+        "empathy",
+        "instinct"
+      ],
+      "meanings": {
+        "light": [
+          "Allowing yourself to be moved by the plight of others",
+          "Feeling strong emotions",
+          "Possessing unusual sympathy or empathy",
+          "Trusting your feelings to guide you",
+          "Calling on psychic abilities",
+          "Achieving unity with Spirit"
+        ],
+        "shadow": [
+          "Becoming so caught up in matters of Spirit, you become detached from the world",
+          "Allowing empathy to disable you (instead of inspire action)",
+          "Using psychic abilities to wield covert influence",
+          "Wallowing in emotionalism, sentiment, or self-pity"
+        ]
+      },
+      "Elemental": "Water of Water.",
+      "Affirmation": "\"I choose to be enabled, not disabled, by my strong emotions.\"",
+      "Questions to Ask": [
+        "How do I handle strong emotions?",
+        "To what extent am I a victim of my own feelings?",
+        "How can I move from reflection to action?"
+      ],
+      "hash64": "99e292fc254f53bc29389b38c3f714f5a9c1d74521e6bdfdf2e58cc2815b485e"
     },
     {
       "name": "King of Cups",
@@ -1425,34 +1600,39 @@
       "arcana": "Minor Arcana",
       "suit": "Cups",
       "img": "c14.jpg",
-	  "fortune_telling": [
-                "This card represents an older man with a gentle, sensitive presence, likely born between February 9th and March 10th, who is known for his fairness and tolerance"
-            ], 
-            "keywords": [
-                "wisdom", 
-                "diplomacy", 
-                "restraint", 
-                "composure"
-            ], 
-            "meanings": {
-                "light": [
-                    "Keeping a stiff upper lip", 
-                    "Being brave and clear in the face of adverse circumstances", 
-                    "Sharing experience as a way of comforting others", 
-                    "Making fair and empathetic decisions", 
-                    "Honoring the spirit, not just the letter, of the law"
-                ], 
-                "shadow": [
-                    "Allowing yourself to become rigid and unemotional", 
-                    "Making unfair decisions based on a hidden agenda", 
-                    "Making decisions without regard for their emotional impact on others", 
-                    "Abusing spiritual authority", 
-                    "Using emotional or spiritual leverage to exercise unhealthy control over others"
-                ]
-            },
-		"Elemental" : "Fire of Water.",
-      "Affirmation" : "\"I strive to be stable and fair-minded.\"",
-	  "Questions to Ask" : ["What wise person could be consulted for good advice?","How can I make sure I'm being as objective and fair as possible?","To what extent am I capable of keeping a \"stiff upper lip?\""]
+      "fortune_telling": [
+        "This card represents an older man with a gentle, sensitive presence, likely born between February 9th and March 10th, who is known for his fairness and tolerance"
+      ],
+      "keywords": [
+        "wisdom",
+        "diplomacy",
+        "restraint",
+        "composure"
+      ],
+      "meanings": {
+        "light": [
+          "Keeping a stiff upper lip",
+          "Being brave and clear in the face of adverse circumstances",
+          "Sharing experience as a way of comforting others",
+          "Making fair and empathetic decisions",
+          "Honoring the spirit, not just the letter, of the law"
+        ],
+        "shadow": [
+          "Allowing yourself to become rigid and unemotional",
+          "Making unfair decisions based on a hidden agenda",
+          "Making decisions without regard for their emotional impact on others",
+          "Abusing spiritual authority",
+          "Using emotional or spiritual leverage to exercise unhealthy control over others"
+        ]
+      },
+      "Elemental": "Fire of Water.",
+      "Affirmation": "\"I strive to be stable and fair-minded.\"",
+      "Questions to Ask": [
+        "What wise person could be consulted for good advice?",
+        "How can I make sure I'm being as objective and fair as possible?",
+        "To what extent am I capable of keeping a \"stiff upper lip?\""
+      ],
+      "hash64": "8c0d75afbe841608d9a19ec1105d330fe61dab8a7e7d28fa3d9f31e1bea3089a"
     },
     {
       "name": "Ace of Swords",
@@ -1460,39 +1640,44 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s01.jpg",
-	  "fortune_telling": [
-                "The time to make a choice is now", 
-                "Stop wavering and do what you know is best"
-            ], 
-            "keywords": [
-                "logic", 
-                "objectivity", 
-                "intellect", 
-                "choice"
-            ], 
-            "meanings": {
-                "light": [
-                    "Making objective decisions", 
-                    "Applying logic", 
-                    "Reasoning your way out of a difficult situation", 
-                    "Solving puzzles", 
-                    "Thinking things through", 
-                    "Emphasizing the facts", 
-                    "Clearing your mind", 
-                    "Seeking clarity"
-                ], 
-                "shadow": [
-                    "Applying ruthless or twisted logic", 
-                    "Gloating over your own superior intellect", 
-                    "Using quick thinking to deceive or confuse others", 
-                    "Confusing snap judgments with quick thinking", 
-                    "Making decisions without thinking through consequences"
-                ]
-            },
-		"Numerology" : "1 (The Origin: the starting point, the seed, opportunity)",
-      "Astrology" : "Libra, Aquarius, Gemini",
-      "Affirmation" : "\"I take the time to think things through.\"",
-	  "Questions to Ask" : ["If I made my decision purely based on reason and logic, what would my decision be?","What do I think about my own problem-solving ability?","Who can supply me with the pure and simple facts?"]
+      "fortune_telling": [
+        "The time to make a choice is now",
+        "Stop wavering and do what you know is best"
+      ],
+      "keywords": [
+        "logic",
+        "objectivity",
+        "intellect",
+        "choice"
+      ],
+      "meanings": {
+        "light": [
+          "Making objective decisions",
+          "Applying logic",
+          "Reasoning your way out of a difficult situation",
+          "Solving puzzles",
+          "Thinking things through",
+          "Emphasizing the facts",
+          "Clearing your mind",
+          "Seeking clarity"
+        ],
+        "shadow": [
+          "Applying ruthless or twisted logic",
+          "Gloating over your own superior intellect",
+          "Using quick thinking to deceive or confuse others",
+          "Confusing snap judgments with quick thinking",
+          "Making decisions without thinking through consequences"
+        ]
+      },
+      "Numerology": "1 (The Origin: the starting point, the seed, opportunity)",
+      "Astrology": "Libra, Aquarius, Gemini",
+      "Affirmation": "\"I take the time to think things through.\"",
+      "Questions to Ask": [
+        "If I made my decision purely based on reason and logic, what would my decision be?",
+        "What do I think about my own problem-solving ability?",
+        "Who can supply me with the pure and simple facts?"
+      ],
+      "hash64": "734cb4fade579123b505db479a6debcbda737dfa6754559d3642c6de5ca21eed"
     },
     {
       "name": "Two of Swords",
@@ -1500,37 +1685,42 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s02.jpg",
-	  "fortune_telling": [
-                "Sometimes, the only way to win is to refuse to fight", 
-                "You're stuck for now; let time pass before taking action"
-            ], 
-            "keywords": [
-                "denial", 
-                "debate", 
-                "impasse", 
-                "truce"
-            ], 
-            "meanings": {
-                "light": [
-                    "Refusing to make a decision without getting the facts", 
-                    "Exploring both sides of an argument", 
-                    "Arguing passionately for what you believe in", 
-                    "Weighing the issues", 
-                    "Encouraging the open exchange of ideas", 
-                    "Discussing political or religious issues without getting \"hot under the collar\""
-                ], 
-                "shadow": [
-                    "Rejecting evidence that conflicts with dearly-held beliefs", 
-                    "Arguing with others just for the sake of doing so", 
-                    "Nit-picking", 
-                    "Putting off a decision because you're afraid to face the consequences", 
-                    "Preventing others from getting the information they need to make good decisions"
-                ]
-            },
-		"Numerology" : "2 (The Other: duality, division, debate)",
-      "Astrology" : "Moon in Libra",
-      "Affirmation" : "\"I strive to see all sides of every issue.\"",
-	  "Questions to Ask" : ["What information do I need to get past this impasse?","How can I get past being defensive and see the facts?","What viewpoints, other than my own, play a role in this situation?"]
+      "fortune_telling": [
+        "Sometimes, the only way to win is to refuse to fight",
+        "You're stuck for now; let time pass before taking action"
+      ],
+      "keywords": [
+        "denial",
+        "debate",
+        "impasse",
+        "truce"
+      ],
+      "meanings": {
+        "light": [
+          "Refusing to make a decision without getting the facts",
+          "Exploring both sides of an argument",
+          "Arguing passionately for what you believe in",
+          "Weighing the issues",
+          "Encouraging the open exchange of ideas",
+          "Discussing political or religious issues without getting \"hot under the collar\""
+        ],
+        "shadow": [
+          "Rejecting evidence that conflicts with dearly-held beliefs",
+          "Arguing with others just for the sake of doing so",
+          "Nit-picking",
+          "Putting off a decision because you're afraid to face the consequences",
+          "Preventing others from getting the information they need to make good decisions"
+        ]
+      },
+      "Numerology": "2 (The Other: duality, division, debate)",
+      "Astrology": "Moon in Libra",
+      "Affirmation": "\"I strive to see all sides of every issue.\"",
+      "Questions to Ask": [
+        "What information do I need to get past this impasse?",
+        "How can I get past being defensive and see the facts?",
+        "What viewpoints, other than my own, play a role in this situation?"
+      ],
+      "hash64": "d40a17933cfb6d40e23a78fd00aea28364b7524832bdf40e78bb9730c4b05ae6"
     },
     {
       "name": "Three of Swords",
@@ -1538,37 +1728,42 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s03.jpg",
-	  "fortune_telling": [
-                "Breakups and infidelity abound", 
-                "What hurts now, though, will turn out to be good for you later on"
-            ], 
-            "keywords": [
-                "variance", 
-                "difference", 
-                "dissatisfaction", 
-                "heartache", 
-                "rejection"
-            ], 
-            "meanings": {
-                "light": [
-                    "Being brave enough to see things as they really are", 
-                    "Exercising your critical eye", 
-                    "Being your own best critic", 
-                    "Acknowledging that things don't always turn out as planned", 
-                    "Moving past heartbreak to embrace a painful truth"
-                ], 
-                "shadow": [
-                    "Wallowing in despair", 
-                    "Allowing yourself to be completely crushed by the thoughts, words, or deeds of another", 
-                    "Judging yourself too harshly", 
-                    "Holding yourself to an unrealistic standard of excellence", 
-                    "Wearing your heart on your sleeve while carrying a chip on your shoulder"
-                ]
-            },
-		 "Numerology" : "3 (The Result: expression, productivity, output)",
-      "Astrology" : "Saturn in Libra",
-      "Affirmation" : "\"I learn from failures and setbacks.\"",
-	   "Questions to Ask" : ["How can I get past my depression?","To what extent are my emotions a matter of choice?","How can I learn from the mistakes of the past?"]
+      "fortune_telling": [
+        "Breakups and infidelity abound",
+        "What hurts now, though, will turn out to be good for you later on"
+      ],
+      "keywords": [
+        "variance",
+        "difference",
+        "dissatisfaction",
+        "heartache",
+        "rejection"
+      ],
+      "meanings": {
+        "light": [
+          "Being brave enough to see things as they really are",
+          "Exercising your critical eye",
+          "Being your own best critic",
+          "Acknowledging that things don't always turn out as planned",
+          "Moving past heartbreak to embrace a painful truth"
+        ],
+        "shadow": [
+          "Wallowing in despair",
+          "Allowing yourself to be completely crushed by the thoughts, words, or deeds of another",
+          "Judging yourself too harshly",
+          "Holding yourself to an unrealistic standard of excellence",
+          "Wearing your heart on your sleeve while carrying a chip on your shoulder"
+        ]
+      },
+      "Numerology": "3 (The Result: expression, productivity, output)",
+      "Astrology": "Saturn in Libra",
+      "Affirmation": "\"I learn from failures and setbacks.\"",
+      "Questions to Ask": [
+        "How can I get past my depression?",
+        "To what extent are my emotions a matter of choice?",
+        "How can I learn from the mistakes of the past?"
+      ],
+      "hash64": "8bcbb29f5d0eb6f5fcd3c261101adba9a7d3c897b3d68a6225aae668d870eae9"
     },
     {
       "name": "Four of Swords",
@@ -1576,35 +1771,40 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s04.jpg",
-	  "fortune_telling": [
-                "Don't make any decision now", 
-                "Wait, and you'll be glad you did"
-            ], 
-            "keywords": [
-                "meditation", 
-                "contemplation", 
-                "perspective", 
-                "mindset"
-            ], 
-            "meanings": {
-                "light": [
-                    "Thinking over your plans before putting them into action", 
-                    "Pausing to meditate or clear your mind", 
-                    "Taking time to understand someone or something before criticizing it", 
-                    "Resting", 
-                    "Occupying your thoughts with a healthy distraction"
-                ], 
-                "shadow": [
-                    "Failing to think things through", 
-                    "Mistaking procrastination for thoughtfulness", 
-                    "Adopting a point of view and refusing to reconsider your conclusions, even when presented with refuting evidence", 
-                    "Allowing chaos and whimsy to dominate your thoughts"
-                ]
-            },
-		"Numerology" : "4 (The Status Quo: stability, equality, persistence)",
-      "Astrology" : "Jupiter in Libra",
-      "Affirmation" : "\"I think before taking action.\"",
-	  "Questions to Ask" : ["How long has it been since you deliberately took a \"time out?\"","How difficult is it for you to meditate?","What would happen if you simply refused to make a decision today?"]
+      "fortune_telling": [
+        "Don't make any decision now",
+        "Wait, and you'll be glad you did"
+      ],
+      "keywords": [
+        "meditation",
+        "contemplation",
+        "perspective",
+        "mindset"
+      ],
+      "meanings": {
+        "light": [
+          "Thinking over your plans before putting them into action",
+          "Pausing to meditate or clear your mind",
+          "Taking time to understand someone or something before criticizing it",
+          "Resting",
+          "Occupying your thoughts with a healthy distraction"
+        ],
+        "shadow": [
+          "Failing to think things through",
+          "Mistaking procrastination for thoughtfulness",
+          "Adopting a point of view and refusing to reconsider your conclusions, even when presented with refuting evidence",
+          "Allowing chaos and whimsy to dominate your thoughts"
+        ]
+      },
+      "Numerology": "4 (The Status Quo: stability, equality, persistence)",
+      "Astrology": "Jupiter in Libra",
+      "Affirmation": "\"I think before taking action.\"",
+      "Questions to Ask": [
+        "How long has it been since you deliberately took a \"time out?\"",
+        "How difficult is it for you to meditate?",
+        "What would happen if you simply refused to make a decision today?"
+      ],
+      "hash64": "b711eb6a3b4203aeb9502995f5bb167986b4b3f893b411e90795a6ce0d39267b"
     },
     {
       "name": "Five of Swords",
@@ -1612,40 +1812,45 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s05.jpg",
-	  "fortune_telling": [
-                "Someone is stealing from you, financially or romantically", 
-                "Be wary of friends who talk behind your back"
-            ], 
-            "keywords": [
-                "selfishness", 
-                "hostility", 
-                "irrationality", 
-                "self-preservation"
-            ], 
-            "meanings": {
-                "light": [
-                    "Acting in your own best interest", 
-                    "Choosing to stand up for yourself", 
-                    "Not backing down from disagreement and discord", 
-                    "Taking a stand", 
-                    "Refusing to go along with an unethical plan", 
-                    "Knowing when to bend the rules"
-                ], 
-                "shadow": [
-                    "Taking advantage of others", 
-                    "Intimidating others", 
-                    "Acting in an unethical manner", 
-                    "Picking fights", 
-                    "Using words to goad others into violence and irrationality", 
-                    "Ignoring rules you've agreed to abide by", 
-                    "Looking out for yourself while allowing harm to come to others", 
-                    "Gloating over victory"
-                ]
-            },
-		"Numerology" : "5 (The Catalyst: instability, resistance, confrontation)",
-      "Astrology" : "Venus in Aquarius",
-      "Affirmation" : "\"Even as I care for myself, I am mindful of the needs of others.\"",
-	  "Questions to Ask" : ["How do I behave when I win? What does that say about me?","How can I do what's necessary without making others feel defeated?","What's the difference between selfish action and acting in my own best interest?"]
+      "fortune_telling": [
+        "Someone is stealing from you, financially or romantically",
+        "Be wary of friends who talk behind your back"
+      ],
+      "keywords": [
+        "selfishness",
+        "hostility",
+        "irrationality",
+        "self-preservation"
+      ],
+      "meanings": {
+        "light": [
+          "Acting in your own best interest",
+          "Choosing to stand up for yourself",
+          "Not backing down from disagreement and discord",
+          "Taking a stand",
+          "Refusing to go along with an unethical plan",
+          "Knowing when to bend the rules"
+        ],
+        "shadow": [
+          "Taking advantage of others",
+          "Intimidating others",
+          "Acting in an unethical manner",
+          "Picking fights",
+          "Using words to goad others into violence and irrationality",
+          "Ignoring rules you've agreed to abide by",
+          "Looking out for yourself while allowing harm to come to others",
+          "Gloating over victory"
+        ]
+      },
+      "Numerology": "5 (The Catalyst: instability, resistance, confrontation)",
+      "Astrology": "Venus in Aquarius",
+      "Affirmation": "\"Even as I care for myself, I am mindful of the needs of others.\"",
+      "Questions to Ask": [
+        "How do I behave when I win? What does that say about me?",
+        "How can I do what's necessary without making others feel defeated?",
+        "What's the difference between selfish action and acting in my own best interest?"
+      ],
+      "hash64": "103d18bd6e31fc7471641d9ae343e0d58034c6229c1d3737a7d5ca9dd38f5451"
     },
     {
       "name": "Six of Swords",
@@ -1653,38 +1858,43 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s06.jpg",
-	  "fortune_telling": [
-                "You'll soon go on a long journey over water", 
-                "Actions have unexpected consequences, so be prepared"
-            ], 
-            "keywords": [
-                "adaptation", 
-                "adjustments", 
-                "science", 
-                "travel"
-            ], 
-            "meanings": {
-                "light": [
-                    "Making the best of a bad situation", 
-                    "Recovering from defeat", 
-                    "Resetting expectations", 
-                    "Making allowances for unexpected circumstances", 
-                    "Helping others who find themselves in dire circumstances", 
-                    "Changing the way you see the world", 
-                    "Broadening your perspective through study or travel"
-                ], 
-                "shadow": [
-                    "Refusing to accept that things have changed", 
-                    "Playing the victim", 
-                    "Rejecting the idea that your actions have consequences", 
-                    "Applying scientific criteria to matters of faith, or confusing faith with science", 
-                    "Believing the whole world should be like your small corner of it"
-                ]
-            },
-		"Numerology" : "6 (The Adjustment: cooperation, collaboration, interaction)",
-      "Astrology" : "Mercury in Aquarius",
-      "Affirmation" : "\"I keep an open mind.\"",
-	   "Questions to Ask" : ["What assumptions govern my thinking?","How willing am I to lend aid to others? To request it when I need it?","How prepared am I to deal with change? With unexpected outcomes?"]
+      "fortune_telling": [
+        "You'll soon go on a long journey over water",
+        "Actions have unexpected consequences, so be prepared"
+      ],
+      "keywords": [
+        "adaptation",
+        "adjustments",
+        "science",
+        "travel"
+      ],
+      "meanings": {
+        "light": [
+          "Making the best of a bad situation",
+          "Recovering from defeat",
+          "Resetting expectations",
+          "Making allowances for unexpected circumstances",
+          "Helping others who find themselves in dire circumstances",
+          "Changing the way you see the world",
+          "Broadening your perspective through study or travel"
+        ],
+        "shadow": [
+          "Refusing to accept that things have changed",
+          "Playing the victim",
+          "Rejecting the idea that your actions have consequences",
+          "Applying scientific criteria to matters of faith, or confusing faith with science",
+          "Believing the whole world should be like your small corner of it"
+        ]
+      },
+      "Numerology": "6 (The Adjustment: cooperation, collaboration, interaction)",
+      "Astrology": "Mercury in Aquarius",
+      "Affirmation": "\"I keep an open mind.\"",
+      "Questions to Ask": [
+        "What assumptions govern my thinking?",
+        "How willing am I to lend aid to others? To request it when I need it?",
+        "How prepared am I to deal with change? With unexpected outcomes?"
+      ],
+      "hash64": "c2a4e73d508120a565e7f517aac293991b388c5dcb01d3d35a54ebf27b6b8f55"
     },
     {
       "name": "Seven of Swords",
@@ -1692,36 +1902,41 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s07.jpg",
-	  "fortune_telling": [
-                "Don't assume people around you are worthy of your trust", 
-                "Ask for an accounting of where people have been, and what they've been doing"
-            ], 
-            "keywords": [
-                "dishonesty", 
-                "presumption", 
-                "sneakiness", 
-                "assumptions"
-            ], 
-            "meanings": {
-                "light": [
-                    "Refusing to do something dishonest, even when there's no chance of ever being caught", 
-                    "Handling a difficult situation with finesse", 
-                    "Pointing out assumptions", 
-                    "Acting ethically in public and in private", 
-                    "Living a life that is beyond reproach"
-                ], 
-                "shadow": [
-                    "Stealing or lying", 
-                    "Doing whatever you can get away with, simply because you can", 
-                    "Looking for a way around consequences", 
-                    "Justifying wicked behavior by focusing on the wickedness of others", 
-                    "Failing to examine your own motives and prejudices"
-                ]
-            },
-		"Numerology" : "7 (The Motive: imagination, inner work, psychology)",
-      "Astrology" : "Moon in Aquarius",
-      "Affirmation" : "\"I hold myself to the highest ethical standards.\"",
-	  "Questions to Ask" : ["What assumptions am I making?","How well-defined is my sense of ethics?","How should I respond when I know others are breaking the rules?"]
+      "fortune_telling": [
+        "Don't assume people around you are worthy of your trust",
+        "Ask for an accounting of where people have been, and what they've been doing"
+      ],
+      "keywords": [
+        "dishonesty",
+        "presumption",
+        "sneakiness",
+        "assumptions"
+      ],
+      "meanings": {
+        "light": [
+          "Refusing to do something dishonest, even when there's no chance of ever being caught",
+          "Handling a difficult situation with finesse",
+          "Pointing out assumptions",
+          "Acting ethically in public and in private",
+          "Living a life that is beyond reproach"
+        ],
+        "shadow": [
+          "Stealing or lying",
+          "Doing whatever you can get away with, simply because you can",
+          "Looking for a way around consequences",
+          "Justifying wicked behavior by focusing on the wickedness of others",
+          "Failing to examine your own motives and prejudices"
+        ]
+      },
+      "Numerology": "7 (The Motive: imagination, inner work, psychology)",
+      "Astrology": "Moon in Aquarius",
+      "Affirmation": "\"I hold myself to the highest ethical standards.\"",
+      "Questions to Ask": [
+        "What assumptions am I making?",
+        "How well-defined is my sense of ethics?",
+        "How should I respond when I know others are breaking the rules?"
+      ],
+      "hash64": "0b36d18fc8e76141d69b7e987521e05ad0339e2d94991aaf641d0b9ac58cbbde"
     },
     {
       "name": "Eight of Swords",
@@ -1729,41 +1944,46 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s08.jpg",
-	  "fortune_telling": [
-                "Get over playing the victim", 
-                "Once you realize you are your own biggest obstacle, nothing can hold you back"
-            ], 
-            "keywords": [
-                "restriction", 
-                "limitation", 
-                "confinement", 
-                "helplessness"
-            ], 
-            "meanings": {
-                "light": [
-                    "Honoring limits", 
-                    "Respecting the rules", 
-                    "Deciding to go on a diet for your health's sake", 
-                    "Recognizing you cannot always be in control", 
-                    "Identifying obstacles to further progress", 
-                    "Refusing to think about unhealthy or unethical options", 
-                    "Asking for assistance"
-                ], 
-                "shadow": [
-                    "Feeling trapped", 
-                    "Being lost in a maze of rules and regulations", 
-                    "Giving in to despair", 
-                    "Playing the victim", 
-                    "Allowing others to dictate what you can and cannot do", 
-                    "Being rendered helpless", 
-                    "Having very few options", 
-                    "Failing to look for a way out"
-                ]
-            },
-		 "Numerology" : "8 (The Action: movement, outer work, swiftness)",
-      "Astrology" : "Jupiter in Gemini",
-      "Affirmation" : "\"I know my own limits.\"",
-	  "Questions to Ask" : ["Who's empowered to cut through the red tape?","What, exactly, are the obstacles? What resources, exactly, are needed to move them?","To what extent is your powerlessness a matter of attitude?"]
+      "fortune_telling": [
+        "Get over playing the victim",
+        "Once you realize you are your own biggest obstacle, nothing can hold you back"
+      ],
+      "keywords": [
+        "restriction",
+        "limitation",
+        "confinement",
+        "helplessness"
+      ],
+      "meanings": {
+        "light": [
+          "Honoring limits",
+          "Respecting the rules",
+          "Deciding to go on a diet for your health's sake",
+          "Recognizing you cannot always be in control",
+          "Identifying obstacles to further progress",
+          "Refusing to think about unhealthy or unethical options",
+          "Asking for assistance"
+        ],
+        "shadow": [
+          "Feeling trapped",
+          "Being lost in a maze of rules and regulations",
+          "Giving in to despair",
+          "Playing the victim",
+          "Allowing others to dictate what you can and cannot do",
+          "Being rendered helpless",
+          "Having very few options",
+          "Failing to look for a way out"
+        ]
+      },
+      "Numerology": "8 (The Action: movement, outer work, swiftness)",
+      "Astrology": "Jupiter in Gemini",
+      "Affirmation": "\"I know my own limits.\"",
+      "Questions to Ask": [
+        "Who's empowered to cut through the red tape?",
+        "What, exactly, are the obstacles? What resources, exactly, are needed to move them?",
+        "To what extent is your powerlessness a matter of attitude?"
+      ],
+      "hash64": "bc3a1974151162b671b1e5db0b4964462e005d43ff92b5e05ffd8af2db44d44b"
     },
     {
       "name": "Nine of Swords",
@@ -1771,39 +1991,44 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s09.jpg",
-	  "fortune_telling": [
-                "If you take the action you're considering now, you'll be sorry in the future"
-            ], 
-            "keywords": [
-                "remorse", 
-                "worry", 
-                "distraught", 
-                "conclusion"
-            ], 
-            "meanings": {
-                "light": [
-                    "Refusing to worry about what you cannot control", 
-                    "Rejecting anxiety", 
-                    "Judging your own performance with kindness and gentleness", 
-                    "Using meditation to quiet a troubled mind", 
-                    "Confronting nightmares and fears", 
-                    "Drawing a conclusion and putting an issue out of your mind"
-                ], 
-                "shadow": [
-                    "Torturing yourself with regrets", 
-                    "Second-guessing your every move", 
-                    "Beating yourself up for your mistakes", 
-                    "Depression", 
-                    "Obsessing on errors and overlooked details", 
-                    "Refusing to handle stress in healthy ways", 
-                    "Ruining your ability to appreciate the present by dwelling on the past", 
-                    "Debating irreversible decisions"
-                ]
-            },
-		"Numerology" : "9 (The Completion: fullness, readiness, ripeness)",
-      "Astrology" : "Mars in Gemini",
-      "Affirmation" : "\"I do not worry about what I cannot control.\"",
-	   "Questions to Ask" : ["What role does worry play in your current situation?","To what other ends might you devote the energy you're giving to anxiety?","How can you know when it's time to stop thinking and start acting?"]
+      "fortune_telling": [
+        "If you take the action you're considering now, you'll be sorry in the future"
+      ],
+      "keywords": [
+        "remorse",
+        "worry",
+        "distraught",
+        "conclusion"
+      ],
+      "meanings": {
+        "light": [
+          "Refusing to worry about what you cannot control",
+          "Rejecting anxiety",
+          "Judging your own performance with kindness and gentleness",
+          "Using meditation to quiet a troubled mind",
+          "Confronting nightmares and fears",
+          "Drawing a conclusion and putting an issue out of your mind"
+        ],
+        "shadow": [
+          "Torturing yourself with regrets",
+          "Second-guessing your every move",
+          "Beating yourself up for your mistakes",
+          "Depression",
+          "Obsessing on errors and overlooked details",
+          "Refusing to handle stress in healthy ways",
+          "Ruining your ability to appreciate the present by dwelling on the past",
+          "Debating irreversible decisions"
+        ]
+      },
+      "Numerology": "9 (The Completion: fullness, readiness, ripeness)",
+      "Astrology": "Mars in Gemini",
+      "Affirmation": "\"I do not worry about what I cannot control.\"",
+      "Questions to Ask": [
+        "What role does worry play in your current situation?",
+        "To what other ends might you devote the energy you're giving to anxiety?",
+        "How can you know when it's time to stop thinking and start acting?"
+      ],
+      "hash64": "5aa2eaca22845addcbb18269b7adc8808ef3e32c4f9ba13be544c35e648ba88d"
     },
     {
       "name": "Ten of Swords",
@@ -1811,40 +2036,45 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s10.jpg",
-	  "fortune_telling": [
-                "Disaster", 
-                "Put off plans and do not take action until omens are better"
-            ], 
-            "keywords": [
-                "exhaustion", 
-                "ruin", 
-                "disaster", 
-                "stamina", 
-                "obsession"
-            ], 
-            "meanings": {
-                "light": [
-                    "Seeing the signs that you've reached your limits", 
-                    "Paying attention to what your body is trying to tell you", 
-                    "Giving in to the need for rest and renewal", 
-                    "Acknowledging that you've hit bottom", 
-                    "Committing to a turnaround", 
-                    "Knowing the worst is over"
-                ], 
-                "shadow": [
-                    "Accepting defeat prematurely", 
-                    "Driving yourself to total exhaustion, especially mentally", 
-                    "Experiencing a mental breakdown", 
-                    "Obsessing on a problem to the breaking point", 
-                    "Giving up", 
-                    "Refusing to move from thought to action", 
-                    "Deeply unhealthy thoughts"
-                ]
-            },
-		"Numerology" : "10 (The End: finality, completion, exhaustion)",
-      "Astrology" : "Sun in Gemini",
-      "Affirmation" : "\"When my limits are exceeded, I take action on my own behalf.\"",
-	  "Questions to Ask" : ["What are the signs that the time for debate is over?","How can you tell when interest has given way to obsession?","When your own limits are reached, where can you turn for aid?"]
+      "fortune_telling": [
+        "Disaster",
+        "Put off plans and do not take action until omens are better"
+      ],
+      "keywords": [
+        "exhaustion",
+        "ruin",
+        "disaster",
+        "stamina",
+        "obsession"
+      ],
+      "meanings": {
+        "light": [
+          "Seeing the signs that you've reached your limits",
+          "Paying attention to what your body is trying to tell you",
+          "Giving in to the need for rest and renewal",
+          "Acknowledging that you've hit bottom",
+          "Committing to a turnaround",
+          "Knowing the worst is over"
+        ],
+        "shadow": [
+          "Accepting defeat prematurely",
+          "Driving yourself to total exhaustion, especially mentally",
+          "Experiencing a mental breakdown",
+          "Obsessing on a problem to the breaking point",
+          "Giving up",
+          "Refusing to move from thought to action",
+          "Deeply unhealthy thoughts"
+        ]
+      },
+      "Numerology": "10 (The End: finality, completion, exhaustion)",
+      "Astrology": "Sun in Gemini",
+      "Affirmation": "\"When my limits are exceeded, I take action on my own behalf.\"",
+      "Questions to Ask": [
+        "What are the signs that the time for debate is over?",
+        "How can you tell when interest has given way to obsession?",
+        "When your own limits are reached, where can you turn for aid?"
+      ],
+      "hash64": "8d9269178d2864e4df16f4509ad8769b28ef59415c50aa6f3892081e81ef9d98"
     },
     {
       "name": "Page of Swords",
@@ -1852,37 +2082,42 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s11.jpg",
-	  "fortune_telling": [
-                "This card represents a young man or woman with an airy, intellectual demeanor, likely born a Capricorn, Aquarius, or Pisces, who wants to learn something new from you or have a discussion with you"
-            ], 
-            "keywords": [
-                "student", 
-                "apprentice", 
-                "scholarship", 
-                "information"
-            ], 
-            "meanings": {
-                "light": [
-                    "Pursuing a course of study", 
-                    "Asking good questions", 
-                    "Investing time in study and practice", 
-                    "Doing research", 
-                    "Making a habit of learning new things", 
-                    "Starting an investigation", 
-                    "Outlining what you need to know", 
-                    "Finding a mentor or teacher"
-                ], 
-                "shadow": [
-                    "Pretending to knowledge or sophistication you do not possess", 
-                    "Cheating on an exam", 
-                    "Feigning interest as a way of gaining favor", 
-                    "Considering only the evidence that supports conclusions you've already drawn", 
-                    "Rejecting the wise counsel of experienced teachers"
-                ]
-            },
-		"Elemental" : "Earth of Air.",
-      "Affirmation" : "\"I am ready to make good decisions.\"",
-	   "Questions to Ask" : ["How comfortable are you with revealing your own ignorance?","What are the marks of a good student?","To what extent are you open to new information?"]
+      "fortune_telling": [
+        "This card represents a young man or woman with an airy, intellectual demeanor, likely born a Capricorn, Aquarius, or Pisces, who wants to learn something new from you or have a discussion with you"
+      ],
+      "keywords": [
+        "student",
+        "apprentice",
+        "scholarship",
+        "information"
+      ],
+      "meanings": {
+        "light": [
+          "Pursuing a course of study",
+          "Asking good questions",
+          "Investing time in study and practice",
+          "Doing research",
+          "Making a habit of learning new things",
+          "Starting an investigation",
+          "Outlining what you need to know",
+          "Finding a mentor or teacher"
+        ],
+        "shadow": [
+          "Pretending to knowledge or sophistication you do not possess",
+          "Cheating on an exam",
+          "Feigning interest as a way of gaining favor",
+          "Considering only the evidence that supports conclusions you've already drawn",
+          "Rejecting the wise counsel of experienced teachers"
+        ]
+      },
+      "Elemental": "Earth of Air.",
+      "Affirmation": "\"I am ready to make good decisions.\"",
+      "Questions to Ask": [
+        "How comfortable are you with revealing your own ignorance?",
+        "What are the marks of a good student?",
+        "To what extent are you open to new information?"
+      ],
+      "hash64": "95b81c66e034df3d5d2da7d98fabe7727ce90598171f385e11b9fd4d80c65ab9"
     },
     {
       "name": "Knight of Swords",
@@ -1890,42 +2125,47 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s12.jpg",
-	  "fortune_telling": [
-                "A blunder leads someone to say something he or she regrets", 
-                "If this was you, be prepared to apologize and move on"
-            ], 
-            "keywords": [
-                "bluntness", 
-                "intelligence", 
-                "incisiveness", 
-                "investigation"
-            ], 
-            "meanings": {
-                "light": [
-                    "Speaking your mind", 
-                    "Making your opinions known", 
-                    "Offering constructive criticism", 
-                    "Sharing your knowledge", 
-                    "Making insightful observations", 
-                    "Pinpointing the problem", 
-                    "Clarifying what others have said", 
-                    "Giving clear direction to others", 
-                    "Uncovering the truth"
-                ], 
-                "shadow": [
-                    "Stating your opinions as fact", 
-                    "Picking fights", 
-                    "Starting arguments", 
-                    "Using clever insults to undermine the confidence of others", 
-                    "Tossing reason out the window", 
-                    "Speaking without taking the feelings of others into account", 
-                    "Going on a witch hunt", 
-                    "Distorting evidence"
-                ]
-            },
-		"Elemental" : "Air of Air.",
-      "Affirmation" : "\"I temper my insights with tact.\"",
-	  "Questions to Ask" : ["What do I really need to know?","To what extent have I investigated the facts behind my situation?","How can I share what I know without alienating others?"]
+      "fortune_telling": [
+        "A blunder leads someone to say something he or she regrets",
+        "If this was you, be prepared to apologize and move on"
+      ],
+      "keywords": [
+        "bluntness",
+        "intelligence",
+        "incisiveness",
+        "investigation"
+      ],
+      "meanings": {
+        "light": [
+          "Speaking your mind",
+          "Making your opinions known",
+          "Offering constructive criticism",
+          "Sharing your knowledge",
+          "Making insightful observations",
+          "Pinpointing the problem",
+          "Clarifying what others have said",
+          "Giving clear direction to others",
+          "Uncovering the truth"
+        ],
+        "shadow": [
+          "Stating your opinions as fact",
+          "Picking fights",
+          "Starting arguments",
+          "Using clever insults to undermine the confidence of others",
+          "Tossing reason out the window",
+          "Speaking without taking the feelings of others into account",
+          "Going on a witch hunt",
+          "Distorting evidence"
+        ]
+      },
+      "Elemental": "Air of Air.",
+      "Affirmation": "\"I temper my insights with tact.\"",
+      "Questions to Ask": [
+        "What do I really need to know?",
+        "To what extent have I investigated the facts behind my situation?",
+        "How can I share what I know without alienating others?"
+      ],
+      "hash64": "aebd5d11328a9720d694741e5e3e400f52a83bd0e030ae47c89047eb839ce39c"
     },
     {
       "name": "Queen of Swords",
@@ -1933,41 +2173,46 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s13.jpg",
-	  "fortune_telling": [
-                "This card represents a woman with an artistic, intellectual nature, likely born between September 12th and October 12th, who uses clever, positive communication to sway others to her point of view"
-            ], 
-            "keywords": [
-                "grace", 
-                "skill", 
-                "wit", 
-                "charm", 
-                "aptitude"
-            ], 
-            "meanings": {
-                "light": [
-                    "Exercising tact or using diplomacy", 
-                    "Defusing a tense situation", 
-                    "Knowing what to say and how to say it", 
-                    "Making others feel comfortable and confident", 
-                    "Bringing out the best in everyone", 
-                    "Having a way with words", 
-                    "Telling jokes", 
-                    "Possessing a knack for music, math, art, or science"
-                ], 
-                "shadow": [
-                    "Knowing exactly what to say to destroy another person", 
-                    "Withholding critical information", 
-                    "Using a barbed tongue to upset others", 
-                    "Employing sarcasm", 
-                    "Mimicking others unkindly", 
-                    "Making light of the less fortunate", 
-                    "Being disrespectful", 
-                    "Failing to use the talent you've been given"
-                ]
-            },
-		"Elemental" : "Water of Air.",
-      "Affirmation" : "\"I make the truth easier to hear.\"",
-	  "Questions to Ask" : ["What do I have a knack for? How might my special gift prove useful now?","To what extent am I capable of saying what needs to be said?","What is the best possible way to say what I want to say?"]
+      "fortune_telling": [
+        "This card represents a woman with an artistic, intellectual nature, likely born between September 12th and October 12th, who uses clever, positive communication to sway others to her point of view"
+      ],
+      "keywords": [
+        "grace",
+        "skill",
+        "wit",
+        "charm",
+        "aptitude"
+      ],
+      "meanings": {
+        "light": [
+          "Exercising tact or using diplomacy",
+          "Defusing a tense situation",
+          "Knowing what to say and how to say it",
+          "Making others feel comfortable and confident",
+          "Bringing out the best in everyone",
+          "Having a way with words",
+          "Telling jokes",
+          "Possessing a knack for music, math, art, or science"
+        ],
+        "shadow": [
+          "Knowing exactly what to say to destroy another person",
+          "Withholding critical information",
+          "Using a barbed tongue to upset others",
+          "Employing sarcasm",
+          "Mimicking others unkindly",
+          "Making light of the less fortunate",
+          "Being disrespectful",
+          "Failing to use the talent you've been given"
+        ]
+      },
+      "Elemental": "Water of Air.",
+      "Affirmation": "\"I make the truth easier to hear.\"",
+      "Questions to Ask": [
+        "What do I have a knack for? How might my special gift prove useful now?",
+        "To what extent am I capable of saying what needs to be said?",
+        "What is the best possible way to say what I want to say?"
+      ],
+      "hash64": "873bfe0b84f3320780707b90bb48e375e4be8a0dfa5c7e084dd30f143eaebf31"
     },
     {
       "name": "King of Swords",
@@ -1975,37 +2220,42 @@
       "arcana": "Minor Arcana",
       "suit": "Swords",
       "img": "s14.jpg",
-	  "fortune_telling": [
-                "This card represents an older man with an insightful, deliberate spirit, likely born between May 11th and June 10th, who is known for his integrity and sharp decision-making ability"
-            ], 
-            "keywords": [
-                "genius", 
-                "expertise", 
-                "decision", 
-                "verdict"
-            ], 
-            "meanings": {
-                "light": [
-                    "Expressing yourself with firmness and authority", 
-                    "Rendering a final decision", 
-                    "Consulting an expert", 
-                    "Calling in advisors and consultants", 
-                    "Coming to a final conclusion", 
-                    "Reaching a beneficial agreement based on sound information"
-                ], 
-                "shadow": [
-                    "Insisting on having the last word", 
-                    "Flaunting your intellectual capability", 
-                    "Talking \"over the heads\" of others", 
-                    "Waffling on an important decision", 
-                    "Constantly changing your mind", 
-                    "Refusing to make choices that are in your own best interest", 
-                    "Wishing in vain you could take back what's been said"
-                ]
-            },
-		"Elemental" : "Fire of Air.",
-      "Affirmation" : "\"My word is my bond.\"",
-	  "Questions to Ask" : ["What would your decision be if you had to render a binding verdict right now?","How comfortable are you saying exactly what you mean? How often do you temper what you have to say for fear of offending others?","If you were to ask others, \"What's my area of expertise?\" what would they say?"]
+      "fortune_telling": [
+        "This card represents an older man with an insightful, deliberate spirit, likely born between May 11th and June 10th, who is known for his integrity and sharp decision-making ability"
+      ],
+      "keywords": [
+        "genius",
+        "expertise",
+        "decision",
+        "verdict"
+      ],
+      "meanings": {
+        "light": [
+          "Expressing yourself with firmness and authority",
+          "Rendering a final decision",
+          "Consulting an expert",
+          "Calling in advisors and consultants",
+          "Coming to a final conclusion",
+          "Reaching a beneficial agreement based on sound information"
+        ],
+        "shadow": [
+          "Insisting on having the last word",
+          "Flaunting your intellectual capability",
+          "Talking \"over the heads\" of others",
+          "Waffling on an important decision",
+          "Constantly changing your mind",
+          "Refusing to make choices that are in your own best interest",
+          "Wishing in vain you could take back what's been said"
+        ]
+      },
+      "Elemental": "Fire of Air.",
+      "Affirmation": "\"My word is my bond.\"",
+      "Questions to Ask": [
+        "What would your decision be if you had to render a binding verdict right now?",
+        "How comfortable are you saying exactly what you mean? How often do you temper what you have to say for fear of offending others?",
+        "If you were to ask others, \"What's my area of expertise?\" what would they say?"
+      ],
+      "hash64": "5848ccc7c9d605ab7faa958595f7565302761cc2338cf22df2843fa94e251f09"
     },
     {
       "name": "Ace of Wands",
@@ -2013,41 +2263,46 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w01.jpg",
-	  "fortune_telling": [
-                "Someone has the \"hots\" for you", 
-                "A new job offer is coming your way", 
-                "Walk softly, and carry a big stick"
-            ], 
-            "keywords": [
-                "desire", 
-                "inspiration", 
-                "vision", 
-                "creation", 
-                "invention"
-            ], 
-            "meanings": {
-                "light": [
-                    "Being inspired", 
-                    "Identifying an important goal", 
-                    "Being given the opportunity to do whatever you want to do", 
-                    "Giving or receiving direction", 
-                    "Seeing a solution", 
-                    "Creating something new", 
-                    "Being aroused, sexually or creatively"
-                ], 
-                "shadow": [
-                    "Failing to take advantage of a great opportunity", 
-                    "Being ineffectual or lazy", 
-                    "Making an inadequate effort", 
-                    "Working toward a goal, but lacking the resources or initiative to achieve success", 
-                    "Setting inappropriate goals", 
-                    "Failing to take a stand"
-                ]
-            },
-		"Numerology" : "1 (The Origin: the starting point, the seed, opportunity)",
-      "Astrology" : "Aries, Leo, Sagittarius",
-	  "Affirmation" : "\"I jump at the opportunity to pursue my heart's desire.\"",
-	  "Questions to Ask" : ["What do I really want, more than anything else?","What happens if I let this opportunity pass me by?","How clearly have I defined my directions, values, and goals?"]
+      "fortune_telling": [
+        "Someone has the \"hots\" for you",
+        "A new job offer is coming your way",
+        "Walk softly, and carry a big stick"
+      ],
+      "keywords": [
+        "desire",
+        "inspiration",
+        "vision",
+        "creation",
+        "invention"
+      ],
+      "meanings": {
+        "light": [
+          "Being inspired",
+          "Identifying an important goal",
+          "Being given the opportunity to do whatever you want to do",
+          "Giving or receiving direction",
+          "Seeing a solution",
+          "Creating something new",
+          "Being aroused, sexually or creatively"
+        ],
+        "shadow": [
+          "Failing to take advantage of a great opportunity",
+          "Being ineffectual or lazy",
+          "Making an inadequate effort",
+          "Working toward a goal, but lacking the resources or initiative to achieve success",
+          "Setting inappropriate goals",
+          "Failing to take a stand"
+        ]
+      },
+      "Numerology": "1 (The Origin: the starting point, the seed, opportunity)",
+      "Astrology": "Aries, Leo, Sagittarius",
+      "Affirmation": "\"I jump at the opportunity to pursue my heart's desire.\"",
+      "Questions to Ask": [
+        "What do I really want, more than anything else?",
+        "What happens if I let this opportunity pass me by?",
+        "How clearly have I defined my directions, values, and goals?"
+      ],
+      "hash64": "d8b77e5b3dfaab45b7069def24de4c6aba8bae2ec28e7a5f604a207a66d6cae4"
     },
     {
       "name": "Two of Wands",
@@ -2055,37 +2310,42 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w02.jpg",
-	  "fortune_telling": [
-                "Beware false friends", 
-                "Don't be mealy-mouthed; say what you think and do what you want to do"
-            ], 
-            "keywords": [
-                "conflict", 
-                "decision", 
-                "option", 
-                "individuality"
-            ], 
-            "meanings": {
-                "light": [
-                    "Having a choice", 
-                    "Offering or being offered an option", 
-                    "Seeing the value of another person's approach", 
-                    "Understanding there's more than one way to \"skin a cat\"",
-                    "Successfully doing more than one thing at a time", 
-                    "Being empowered to make a choice"
-                ], 
-                "shadow": [
-                    "Misrepresenting your intentions", 
-                    "Doing one thing while desiring another", 
-                    "Changing course mid-stream for no good reason", 
-                    "Refusing to change your goal even when pursuing it no longer makes sense", 
-                    "Disregarding the input of others"
-                ]
-            },
-	"Numerology" : "2 (The Other: division, debate, duality)",
-      "Astrology" : "Mars in Aries",
-	  "Affirmation" : "\"With my goals in mind, I make confident choices.\"",
-	  "Questions to Ask" : ["In a conflict, how do you decide who wins?","What values govern your decision-making process?","What choice will you make if you make no choice at all?"]
+      "fortune_telling": [
+        "Beware false friends",
+        "Don't be mealy-mouthed; say what you think and do what you want to do"
+      ],
+      "keywords": [
+        "conflict",
+        "decision",
+        "option",
+        "individuality"
+      ],
+      "meanings": {
+        "light": [
+          "Having a choice",
+          "Offering or being offered an option",
+          "Seeing the value of another person's approach",
+          "Understanding there's more than one way to \"skin a cat\"",
+          "Successfully doing more than one thing at a time",
+          "Being empowered to make a choice"
+        ],
+        "shadow": [
+          "Misrepresenting your intentions",
+          "Doing one thing while desiring another",
+          "Changing course mid-stream for no good reason",
+          "Refusing to change your goal even when pursuing it no longer makes sense",
+          "Disregarding the input of others"
+        ]
+      },
+      "Numerology": "2 (The Other: division, debate, duality)",
+      "Astrology": "Mars in Aries",
+      "Affirmation": "\"With my goals in mind, I make confident choices.\"",
+      "Questions to Ask": [
+        "In a conflict, how do you decide who wins?",
+        "What values govern your decision-making process?",
+        "What choice will you make if you make no choice at all?"
+      ],
+      "hash64": "4f2f77ee05362e1baab5a9136c41c46a221333b0e1fea2c099a7a5270b450c5c"
     },
     {
       "name": "Three of Wands",
@@ -2093,37 +2353,42 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w03.jpg",
-	  "fortune_telling": [
-                "You'll be planning a trip soon", 
-                "Be on the lookout: your ship is coming in"
-            ], 
-            "keywords": [
-                "implementation", 
-                "action", 
-                "exploration"
-            ], 
-            "meanings": {
-                "light": [
-                    "Putting a plan into motion", 
-                    "Taking that critical first step", 
-                    "Making good things happen", 
-                    "Going beyond your limits", 
-                    "Blazing new trails", 
-                    "Hitting the ground running", 
-                    "Seeing your plans come to fruition"
-                ], 
-                "shadow": [
-                    "Procrastinating", 
-                    "Knowing what to do, but refusing to do it", 
-                    "Launching a project without a clear definition of who should do what", 
-                    "Rejecting an opportunity to try something new", 
-                    "Failing to finish what you start"
-                ]
-            },
-		"Numerology" : "3 (The Result: expression, productivity, output)",
-      "Astrology" : "Sun in Aries",
-	  "Affirmation" : "\"I take the steps necessary to put my plans in action.\"",
-	  "Questions to Ask" : ["How can you make a habit of breaking your habits?","How can you be a decisive leader in this circumstance?","What's your action plan for the next week, month, year, or decade?"]
+      "fortune_telling": [
+        "You'll be planning a trip soon",
+        "Be on the lookout: your ship is coming in"
+      ],
+      "keywords": [
+        "implementation",
+        "action",
+        "exploration"
+      ],
+      "meanings": {
+        "light": [
+          "Putting a plan into motion",
+          "Taking that critical first step",
+          "Making good things happen",
+          "Going beyond your limits",
+          "Blazing new trails",
+          "Hitting the ground running",
+          "Seeing your plans come to fruition"
+        ],
+        "shadow": [
+          "Procrastinating",
+          "Knowing what to do, but refusing to do it",
+          "Launching a project without a clear definition of who should do what",
+          "Rejecting an opportunity to try something new",
+          "Failing to finish what you start"
+        ]
+      },
+      "Numerology": "3 (The Result: expression, productivity, output)",
+      "Astrology": "Sun in Aries",
+      "Affirmation": "\"I take the steps necessary to put my plans in action.\"",
+      "Questions to Ask": [
+        "How can you make a habit of breaking your habits?",
+        "How can you be a decisive leader in this circumstance?",
+        "What's your action plan for the next week, month, year, or decade?"
+      ],
+      "hash64": "0a619ed4b5377d2a75ac1bd4ec58ed98e7d11d0b1f2ad90e7aa93a665c508044"
     },
     {
       "name": "Four of Wands",
@@ -2131,37 +2396,42 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w04.jpg",
-	  "fortune_telling": [
-                "Someone is watching and evaluating your work", 
-                "You may get a wedding invitation soon"
-            ], 
-            "keywords": [
-                "celebration", 
-                "jubilation", 
-                "community", 
-                "teamwork", 
-                "completion"
-            ], 
-            "meanings": {
-                "light": [
-                    "Sharing in a great celebration", 
-                    "Sharing in a communal sense of achievement and success", 
-                    "Preparing for a party", 
-                    "Working together toward a common goal", 
-                    "Giving or winning awards"
-                ], 
-                "shadow": [
-                    "Keeping your nose to the grindstone", 
-                    "Recognizing good work by demanding more work", 
-                    "Failing to share in a group celebration", 
-                    "Allowing sour grapes to poison your moment in the sun", 
-                    "Refusing to do your part"
-                ]
-            },
-		"Numerology" : "4 (The Status Quo: stability, equality, persistence)",
-      "Astrology" : "Venus in Aries",
-	  "Affirmation" : "\"My contributions are worthy of celebration.\"",
-	  "Questions to Ask" : ["To what extent am I doing my part?","What kind of recognition would be most meaningful?","How might a celebration now impact community morale?"]
+      "fortune_telling": [
+        "Someone is watching and evaluating your work",
+        "You may get a wedding invitation soon"
+      ],
+      "keywords": [
+        "celebration",
+        "jubilation",
+        "community",
+        "teamwork",
+        "completion"
+      ],
+      "meanings": {
+        "light": [
+          "Sharing in a great celebration",
+          "Sharing in a communal sense of achievement and success",
+          "Preparing for a party",
+          "Working together toward a common goal",
+          "Giving or winning awards"
+        ],
+        "shadow": [
+          "Keeping your nose to the grindstone",
+          "Recognizing good work by demanding more work",
+          "Failing to share in a group celebration",
+          "Allowing sour grapes to poison your moment in the sun",
+          "Refusing to do your part"
+        ]
+      },
+      "Numerology": "4 (The Status Quo: stability, equality, persistence)",
+      "Astrology": "Venus in Aries",
+      "Affirmation": "\"My contributions are worthy of celebration.\"",
+      "Questions to Ask": [
+        "To what extent am I doing my part?",
+        "What kind of recognition would be most meaningful?",
+        "How might a celebration now impact community morale?"
+      ],
+      "hash64": "b95fd820c3c0acdb124032f7ef7795eb4645fdc5d928d83f5e1e685aac678f0a"
     },
     {
       "name": "Five of Wands",
@@ -2169,36 +2439,41 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w05.jpg",
-	  "fortune_telling": [
-                "Prepare for a fight with your best friend", 
-                "Remember: once you let words loose, you can't take them back"
-            ], 
-            "keywords": [
-                "confrontation", 
-                "disruption", 
-                "distinction", 
-                "objection", 
-                "strife"
-            ], 
-            "meanings": {
-                "light": [
-                    "Calmly expressing a dissenting opinion", 
-                    "Allowing someone to use his or her own methods to get a job done", 
-                    "Opening the floor for discussion or debate", 
-                    "Comparing progress made so far to standards set earlier"
-                ], 
-                "shadow": [
-                    "Berating others for their ridiculous opinions", 
-                    "Picking fights", 
-                    "Offering destructive criticism", 
-                    "Baiting people with barbed remarks", 
-                    "Disrupting progress with an endless stream of pointless objections"
-                ]
-            },
-		"Numerology" : "5 (The Catalyst: instability, resistance, confrontation)",
-      "Astrology" : "Saturn in Leo",
-	  "Affirmation" : "\"I can express dissent in constructive ways.\"",
-	  "Questions to Ask" : ["To what extent is your current issue worth fighting for?","What alternatives are there to outright conflict?","What happens in a \"fair fight?\" How can you keep this fight fair?"]
+      "fortune_telling": [
+        "Prepare for a fight with your best friend",
+        "Remember: once you let words loose, you can't take them back"
+      ],
+      "keywords": [
+        "confrontation",
+        "disruption",
+        "distinction",
+        "objection",
+        "strife"
+      ],
+      "meanings": {
+        "light": [
+          "Calmly expressing a dissenting opinion",
+          "Allowing someone to use his or her own methods to get a job done",
+          "Opening the floor for discussion or debate",
+          "Comparing progress made so far to standards set earlier"
+        ],
+        "shadow": [
+          "Berating others for their ridiculous opinions",
+          "Picking fights",
+          "Offering destructive criticism",
+          "Baiting people with barbed remarks",
+          "Disrupting progress with an endless stream of pointless objections"
+        ]
+      },
+      "Numerology": "5 (The Catalyst: instability, resistance, confrontation)",
+      "Astrology": "Saturn in Leo",
+      "Affirmation": "\"I can express dissent in constructive ways.\"",
+      "Questions to Ask": [
+        "To what extent is your current issue worth fighting for?",
+        "What alternatives are there to outright conflict?",
+        "What happens in a \"fair fight?\" How can you keep this fight fair?"
+      ],
+      "hash64": "e9f7b7096c369c81d3db6f8b2021a0b9b68d74cf8fa5d51096d86c872c05e214"
     },
     {
       "name": "Six of Wands",
@@ -2206,40 +2481,45 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w06.jpg",
-	  "fortune_telling": [
-                "Someone is planning a party for you, but not everyone feels so good about your recent success", 
-                "Watch out for envious friends"
-            ], 
-            "keywords": [
-                "victory", 
-                "achievement", 
-                "success", 
-                "triumph"
-            ], 
-            "meanings": {
-                "light": [
-                    "Outperforming your peers", 
-                    "Winning a competition", 
-                    "Being recognized as a capable person", 
-                    "Having your \"moment in the spotlight\"",
-                    "Being cheered on by the crowd", 
-                    "Getting an award", 
-                    "Earning the admiration of others", 
-                    "Telling someone, \"Good job!\""
-                ], 
-                "shadow": [
-                    "Being a bad winner", 
-                    "Allowing your achievements to inflate your ego", 
-                    "Looking down on people who seem less capable", 
-                    "Craving to be the center of attention", 
-                    "Giving or receiving insincere praise", 
-                    "Envying the achievements of others"
-                ]
-            },
-		"Numerology" : "6 (The Adjustment: cooperation, collaboration, interaction)",
-      "Astrology" : "Jupiter in Leo",
-	  "Affirmation" : "\"I value sincere praise.\"",
-	   "Questions to Ask" : ["What kind of recognition do I crave? Why?","How freely do I praise the achievements of others?","What happens when the parade is over?"]
+      "fortune_telling": [
+        "Someone is planning a party for you, but not everyone feels so good about your recent success",
+        "Watch out for envious friends"
+      ],
+      "keywords": [
+        "victory",
+        "achievement",
+        "success",
+        "triumph"
+      ],
+      "meanings": {
+        "light": [
+          "Outperforming your peers",
+          "Winning a competition",
+          "Being recognized as a capable person",
+          "Having your \"moment in the spotlight\"",
+          "Being cheered on by the crowd",
+          "Getting an award",
+          "Earning the admiration of others",
+          "Telling someone, \"Good job!\""
+        ],
+        "shadow": [
+          "Being a bad winner",
+          "Allowing your achievements to inflate your ego",
+          "Looking down on people who seem less capable",
+          "Craving to be the center of attention",
+          "Giving or receiving insincere praise",
+          "Envying the achievements of others"
+        ]
+      },
+      "Numerology": "6 (The Adjustment: cooperation, collaboration, interaction)",
+      "Astrology": "Jupiter in Leo",
+      "Affirmation": "\"I value sincere praise.\"",
+      "Questions to Ask": [
+        "What kind of recognition do I crave? Why?",
+        "How freely do I praise the achievements of others?",
+        "What happens when the parade is over?"
+      ],
+      "hash64": "3c7c7df83098ef371c015e8e87709cc6f282ea40f81f109222412a01b0beeeaf"
     },
     {
       "name": "Seven of Wands",
@@ -2247,36 +2527,41 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w07.jpg",
-	  "fortune_telling": [
-                "Don't be surprised by a personal attack", 
-                "Prepare to defend yourself or someone you love"
-            ], 
-            "keywords": [
-                "bravery", 
-                "resolve", 
-                "determination"
-            ], 
-            "meanings": {
-                "light": [
-                    "Refusing to be silenced through fear or intimidation", 
-                    "Continuing a fight against all odds", 
-                    "Being fierce", 
-                    "Defending yourself against physical and emotional attacks", 
-                    "Refusing to put up with abuse", 
-                    "Clinging to your values despite all pressure to abandon them"
-                ], 
-                "shadow": [
-                    "Having a chip on your shoulder", 
-                    "Taking unnecessary risks as a means of proving your fearlessness", 
-                    "Looking for an opportunity to take offense", 
-                    "Responding to constructive criticism with defensiveness", 
-                    "Refusing to stand up for yourself and your beliefs"
-                ]
-            },
-		"Numerology" : "7 (The Motive: imagination, inner work, psychology)",
-      "Astrology" : "Mars in Leo",
-	  "Affirmation" : "\"I am willing to take a stand for what I believe in.\"",
-	  "Questions to Ask" : ["When do you feel most threatened? When do you get defensive?","How capable are you of defending yourself?","What kinds of beliefs are worth defending?"]
+      "fortune_telling": [
+        "Don't be surprised by a personal attack",
+        "Prepare to defend yourself or someone you love"
+      ],
+      "keywords": [
+        "bravery",
+        "resolve",
+        "determination"
+      ],
+      "meanings": {
+        "light": [
+          "Refusing to be silenced through fear or intimidation",
+          "Continuing a fight against all odds",
+          "Being fierce",
+          "Defending yourself against physical and emotional attacks",
+          "Refusing to put up with abuse",
+          "Clinging to your values despite all pressure to abandon them"
+        ],
+        "shadow": [
+          "Having a chip on your shoulder",
+          "Taking unnecessary risks as a means of proving your fearlessness",
+          "Looking for an opportunity to take offense",
+          "Responding to constructive criticism with defensiveness",
+          "Refusing to stand up for yourself and your beliefs"
+        ]
+      },
+      "Numerology": "7 (The Motive: imagination, inner work, psychology)",
+      "Astrology": "Mars in Leo",
+      "Affirmation": "\"I am willing to take a stand for what I believe in.\"",
+      "Questions to Ask": [
+        "When do you feel most threatened? When do you get defensive?",
+        "How capable are you of defending yourself?",
+        "What kinds of beliefs are worth defending?"
+      ],
+      "hash64": "e5cac001d76e68cc1d4a18896abbdcb9a918c3d298276f6dd049526e597cad86"
     },
     {
       "name": "Eight of Wands",
@@ -2284,39 +2569,44 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w08.jpg",
-	  "fortune_telling": [
-                "Watch for a surprising letter in the mail", 
-                "Your whole world is about to be turned on its ear"
-            ], 
-            "keywords": [
-                "speed", 
-                "swiftness", 
-                "responsiveness", 
-                "change"
-            ], 
-            "meanings": {
-                "light": [
-                    "Taking swift action", 
-                    "Moving forward with a plan as quickly as possible", 
-                    "Energizing yourself", 
-                    "Adapting to sudden changes", 
-                    "Taking setbacks in stride", 
-                    "Embracing the idea that nothing stays the same forever", 
-                    "Reacting quickly and appropriately to unforeseen problems"
-                ], 
-                "shadow": [
-                    "Giving in to panic", 
-                    "Running in circles and screaming", 
-                    "Insisting things must always stay the same", 
-                    "Stirring the pot just to see what will happen", 
-                    "Rushing others", 
-                    "Refusing to re-evaluate a schedule or program, even when it's clearly no longer appropriate"
-                ]
-            },
-		"Numerology" : "8 (The Action: movement, outer work, swiftness)",
-      "Astrology" : "Mercury in Sagittarius",
-	  "Affirmation" : "\"I adapt quickly to change.\"",
-	  "Questions to Ask" : ["How quickly to you adapt to change?","What would your response be to overwhelming, sudden change?","What changes are on your horizon? How well have you prepared for them?"]
+      "fortune_telling": [
+        "Watch for a surprising letter in the mail",
+        "Your whole world is about to be turned on its ear"
+      ],
+      "keywords": [
+        "speed",
+        "swiftness",
+        "responsiveness",
+        "change"
+      ],
+      "meanings": {
+        "light": [
+          "Taking swift action",
+          "Moving forward with a plan as quickly as possible",
+          "Energizing yourself",
+          "Adapting to sudden changes",
+          "Taking setbacks in stride",
+          "Embracing the idea that nothing stays the same forever",
+          "Reacting quickly and appropriately to unforeseen problems"
+        ],
+        "shadow": [
+          "Giving in to panic",
+          "Running in circles and screaming",
+          "Insisting things must always stay the same",
+          "Stirring the pot just to see what will happen",
+          "Rushing others",
+          "Refusing to re-evaluate a schedule or program, even when it's clearly no longer appropriate"
+        ]
+      },
+      "Numerology": "8 (The Action: movement, outer work, swiftness)",
+      "Astrology": "Mercury in Sagittarius",
+      "Affirmation": "\"I adapt quickly to change.\"",
+      "Questions to Ask": [
+        "How quickly to you adapt to change?",
+        "What would your response be to overwhelming, sudden change?",
+        "What changes are on your horizon? How well have you prepared for them?"
+      ],
+      "hash64": "22bea128349657da69d14cd0edd48c22d3bf5ec6823b07a194bfd0f4f7e30ae1"
     },
     {
       "name": "Nine of Wands",
@@ -2324,41 +2614,46 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w09.jpg",
-	  "fortune_telling": [
-                "Don't relax yet; there's more to come", 
-                "The test you're facing now is happening for one reason: to show you who your real friends are"
-            ], 
-            "keywords": [
-                "toughness", 
-                "persistence", 
-                "stamina", 
-                "loyalty", 
-                "release"
-            ], 
-            "meanings": {
-                "light": [
-                    "Sticking with it for the duration", 
-                    "Fulfilling your promises and obligations", 
-                    "Bearing up under incredible duress", 
-                    "Dragging yourself across the finish line", 
-                    "Picking yourself up by your own bootstraps", 
-                    "Refusing to quit", 
-                    "Going as far as you can go and being satisfied with your performance"
-                ], 
-                "shadow": [
-                    "Making yourself a martyr", 
-                    "Abandoning your post", 
-                    "Giving up at the first sign of opposition", 
-                    "Being prevented from fulfilling an obligation", 
-                    "Failing to be dependable", 
-                    "Refusing to let something go that needs to be released", 
-                    "Beating a dead horse"
-                ]
-            },
-		"Numerology" : "9 (The Completion: fullness, readiness, ripeness)",
-      "Astrology" : "Moon in Sagittarius",
-	  "Affirmation" : "\"When the going gets tough, I stay the course.\"",
-	  "Questions to Ask" : ["How do you cope when things get really tough?","When you get low, what encourages you to go on?","At what point should you be able to let this situation go?"]
+      "fortune_telling": [
+        "Don't relax yet; there's more to come",
+        "The test you're facing now is happening for one reason: to show you who your real friends are"
+      ],
+      "keywords": [
+        "toughness",
+        "persistence",
+        "stamina",
+        "loyalty",
+        "release"
+      ],
+      "meanings": {
+        "light": [
+          "Sticking with it for the duration",
+          "Fulfilling your promises and obligations",
+          "Bearing up under incredible duress",
+          "Dragging yourself across the finish line",
+          "Picking yourself up by your own bootstraps",
+          "Refusing to quit",
+          "Going as far as you can go and being satisfied with your performance"
+        ],
+        "shadow": [
+          "Making yourself a martyr",
+          "Abandoning your post",
+          "Giving up at the first sign of opposition",
+          "Being prevented from fulfilling an obligation",
+          "Failing to be dependable",
+          "Refusing to let something go that needs to be released",
+          "Beating a dead horse"
+        ]
+      },
+      "Numerology": "9 (The Completion: fullness, readiness, ripeness)",
+      "Astrology": "Moon in Sagittarius",
+      "Affirmation": "\"When the going gets tough, I stay the course.\"",
+      "Questions to Ask": [
+        "How do you cope when things get really tough?",
+        "When you get low, what encourages you to go on?",
+        "At what point should you be able to let this situation go?"
+      ],
+      "hash64": "93b78da617a9fe48319b93c929369d9f158a0803bc125bfaef15d0f9875ca84d"
     },
     {
       "name": "Ten of Wands",
@@ -2366,36 +2661,41 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w10.jpg",
-	  "fortune_telling": [
-                "You're worn out",
-                "Back off, take a time out, and let someone else handle things for a while"
-            ], 
-            "keywords": [
-                "exhaustion", 
-                "resistance", 
-                "burden", 
-                "oppression"
-            ], 
-            "meanings": {
-                "light": [
-                    "Holding your own in extreme circumstances", 
-                    "Helping others carry their burdens", 
-                    "Coming to the aid of the oppressed", 
-                    "Knowing and being honest about your own limits", 
-                    "Recognizing when you are not well-suited for a particular task"
-                ], 
-                "shadow": [
-                    "Taking on more work than you know you can handle", 
-                    "Refusing to say \"No\" when you're already overloaded", 
-                    "Making a habit of working overtime", 
-                    "Shielding others from facing the consequences of their own poor judgment", 
-                    "Over-extending yourself on a regular basis"
-                ]
-            },
-		"Numerology" : "10 (The End: finality, completion, exhaustion)",
-      "Astrology" : "Saturn in Sagittarius",
-	  "Affirmation" : "\"I respect my own limits.\"",
-	  "Questions to Ask" : ["How will you know when you reach the end of your rope?","How easily do you say no to new projects and requests?","What projects could you delegate...or eliminate?"]
+      "fortune_telling": [
+        "You're worn out",
+        "Back off, take a time out, and let someone else handle things for a while"
+      ],
+      "keywords": [
+        "exhaustion",
+        "resistance",
+        "burden",
+        "oppression"
+      ],
+      "meanings": {
+        "light": [
+          "Holding your own in extreme circumstances",
+          "Helping others carry their burdens",
+          "Coming to the aid of the oppressed",
+          "Knowing and being honest about your own limits",
+          "Recognizing when you are not well-suited for a particular task"
+        ],
+        "shadow": [
+          "Taking on more work than you know you can handle",
+          "Refusing to say \"No\" when you're already overloaded",
+          "Making a habit of working overtime",
+          "Shielding others from facing the consequences of their own poor judgment",
+          "Over-extending yourself on a regular basis"
+        ]
+      },
+      "Numerology": "10 (The End: finality, completion, exhaustion)",
+      "Astrology": "Saturn in Sagittarius",
+      "Affirmation": "\"I respect my own limits.\"",
+      "Questions to Ask": [
+        "How will you know when you reach the end of your rope?",
+        "How easily do you say no to new projects and requests?",
+        "What projects could you delegate...or eliminate?"
+      ],
+      "hash64": "0d87e25fda6fbc8a05d5e77b6eaea293323e8dfeb6f28b58a633185d3506d3e7"
     },
     {
       "name": "Page of Wands",
@@ -2403,35 +2703,40 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w11.jpg",
-	  "fortune_telling": [
-                "This card represents a young man or woman with a fiery, enthusiastic demeanor, likely born a Cancer, Leo, or Virgo, who wants to start a new relationship with you"
-            ], 
-            "keywords": [
-                "enthusiasm", 
-                "eagerness", 
-                "confidence", 
-                "validation", 
-                "affirmation"
-            ], 
-            "meanings": {
-                "light": [
-                    "Leaping at a new opportunity", 
-                    "Being a cheerleader or ardent advocate for your cause", 
-                    "Being a True Believer", 
-                    "Taking first steps toward independence", 
-                    "Trusting in your own abilities", 
-                    "Asking for feedback"
-                ], 
-                "shadow": [
-                    "Basing your entire self-image on what others think", 
-                    "Seizing every new idea that comes your way without question", 
-                    "Habitually discounting input or feedback from others", 
-                    "Being so eager to \"do it yourself\" that you hinder your own progress"
-                ]
-            },
-	"Elemental" : "Earth of Fire.",
-      "Affirmation" : "\"I can do this.\"",
-	  "Questions to Ask" : ["How easily do you admit your own inexperience?","How can you be a better student or employee?","What qualities would make a total beginner's voyage of discovery easier?"]
+      "fortune_telling": [
+        "This card represents a young man or woman with a fiery, enthusiastic demeanor, likely born a Cancer, Leo, or Virgo, who wants to start a new relationship with you"
+      ],
+      "keywords": [
+        "enthusiasm",
+        "eagerness",
+        "confidence",
+        "validation",
+        "affirmation"
+      ],
+      "meanings": {
+        "light": [
+          "Leaping at a new opportunity",
+          "Being a cheerleader or ardent advocate for your cause",
+          "Being a True Believer",
+          "Taking first steps toward independence",
+          "Trusting in your own abilities",
+          "Asking for feedback"
+        ],
+        "shadow": [
+          "Basing your entire self-image on what others think",
+          "Seizing every new idea that comes your way without question",
+          "Habitually discounting input or feedback from others",
+          "Being so eager to \"do it yourself\" that you hinder your own progress"
+        ]
+      },
+      "Elemental": "Earth of Fire.",
+      "Affirmation": "\"I can do this.\"",
+      "Questions to Ask": [
+        "How easily do you admit your own inexperience?",
+        "How can you be a better student or employee?",
+        "What qualities would make a total beginner's voyage of discovery easier?"
+      ],
+      "hash64": "95e14977f824c6707072f09c1cd654644349ed2f990daef83d698a728abdee92"
     },
     {
       "name": "Knight of Wands",
@@ -2439,37 +2744,42 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w12.jpg",
-	  "fortune_telling": [
-                "This card represents a man with a bold, passionate personality, likely born between July 12th and August 11th, who wants to sweep you off your feet"
-            ], 
-            "keywords": [
-                "boldness", 
-                "bravado", 
-                "passion", 
-                "persuasion", 
-                "advocacy"
-            ], 
-            "meanings": {
-                "light": [
-                    "Charging ahead", 
-                    "Making rapid progress", 
-                    "Refusing limits", 
-                    "Dazzling those around you with your wit and charm", 
-                    "Convincing others of your right to leadership", 
-                    "Convincing others to follow you", 
-                    "Being a catalyst for change"
-                ], 
-                "shadow": [
-                    "Blundering forward with inadequate skill or information", 
-                    "Running roughshod over the feelings of others", 
-                    "Using sex appeal to manipulate others", 
-                    "Forcing your leadership or ideology on others", 
-                    "Beginning many projects without finishing any"
-                ]
-            },
-		"Elemental" : "Air of Fire.",
-      "Affirmation" : "\"I can lead the way to success.\"",
-	  "Questions to Ask" : ["To what extent have you defined your ultimate goal?","What's the fastest way to get the job done? Is this necessarily the best way?","How long has it been since you looked back to see if others really are following your lead?"]
+      "fortune_telling": [
+        "This card represents a man with a bold, passionate personality, likely born between July 12th and August 11th, who wants to sweep you off your feet"
+      ],
+      "keywords": [
+        "boldness",
+        "bravado",
+        "passion",
+        "persuasion",
+        "advocacy"
+      ],
+      "meanings": {
+        "light": [
+          "Charging ahead",
+          "Making rapid progress",
+          "Refusing limits",
+          "Dazzling those around you with your wit and charm",
+          "Convincing others of your right to leadership",
+          "Convincing others to follow you",
+          "Being a catalyst for change"
+        ],
+        "shadow": [
+          "Blundering forward with inadequate skill or information",
+          "Running roughshod over the feelings of others",
+          "Using sex appeal to manipulate others",
+          "Forcing your leadership or ideology on others",
+          "Beginning many projects without finishing any"
+        ]
+      },
+      "Elemental": "Air of Fire.",
+      "Affirmation": "\"I can lead the way to success.\"",
+      "Questions to Ask": [
+        "To what extent have you defined your ultimate goal?",
+        "What's the fastest way to get the job done? Is this necessarily the best way?",
+        "How long has it been since you looked back to see if others really are following your lead?"
+      ],
+      "hash64": "cba0163cd8c9b32f4ef2f00a8cc51e8d2160dfeac2fd96e1c0ff4d64dc5628cf"
     },
     {
       "name": "Queen of Wands",
@@ -2477,33 +2787,38 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w13.jpg",
-	  "fortune_telling": [
-                "This card represents a woman with an attractive, appealing personality, likely born between March 11th and April 20th, who wants to charm you into doing things her way"
-            ], 
-            "keywords": [
-                "attention", 
-                "attraction", 
-                "unification", 
-                "collaboration"
-            ], 
-            "meanings": {
-                "light": [
-                    "Paying close attention", 
-                    "Helping others focus on the issue at hand", 
-                    "Getting everyone to work together", 
-                    "Identifying common ground", 
-                    "Bringing people together, despite their differences", 
-                    "Using reverse psychology"
-                ], 
-                "shadow": [
-                    "Being distracted, or using your charms or skills to distract others from the goal", 
-                    "Calling attention to yourself with negative or unhealthy behaviors", 
-                    "Disrupting group activities as a means of feeding your own ego"
-                ]
-            },
-		"Elemental" : "Water of Fire.",
-      "Affirmation" : "\"I use my influence to promote unity.\"",
-	  "Questions to Ask" : ["How attentive am I?","How can I draw people's attention to what we have in common?","To what extent am I able to convince people to do what I want them to do?"]
+      "fortune_telling": [
+        "This card represents a woman with an attractive, appealing personality, likely born between March 11th and April 20th, who wants to charm you into doing things her way"
+      ],
+      "keywords": [
+        "attention",
+        "attraction",
+        "unification",
+        "collaboration"
+      ],
+      "meanings": {
+        "light": [
+          "Paying close attention",
+          "Helping others focus on the issue at hand",
+          "Getting everyone to work together",
+          "Identifying common ground",
+          "Bringing people together, despite their differences",
+          "Using reverse psychology"
+        ],
+        "shadow": [
+          "Being distracted, or using your charms or skills to distract others from the goal",
+          "Calling attention to yourself with negative or unhealthy behaviors",
+          "Disrupting group activities as a means of feeding your own ego"
+        ]
+      },
+      "Elemental": "Water of Fire.",
+      "Affirmation": "\"I use my influence to promote unity.\"",
+      "Questions to Ask": [
+        "How attentive am I?",
+        "How can I draw people's attention to what we have in common?",
+        "To what extent am I able to convince people to do what I want them to do?"
+      ],
+      "hash64": "2249a7b85f3af42c36f83b7593382fdb4dbe123d6fe1caba43219c048330422f"
     },
     {
       "name": "King of Wands",
@@ -2511,33 +2826,38 @@
       "arcana": "Minor Arcana",
       "suit": "Wands",
       "img": "w14.jpg",
-	  "fortune_telling": [
-                "This card represents an older man with a commanding, charismatic personality, likely born between November 13th and December 12th, who prefers to give directions and have them followed"
-            ], 
-            "keywords": [
-                "creativity", 
-                "ingenuity", 
-                "achievement", 
-                "direction"
-            ], 
-            "meanings": {
-                "light": [
-                    "Putting old things together in new and exciting ways", 
-                    "Coming up with unexpected solutions", 
-                    "Using your experience to solve puzzles and problems", 
-                    "Doing what you set out to do", 
-                    "Directing the efforts of others"
-                ], 
-                "shadow": [
-                    "Using your creativity to get out of honest work", 
-                    "Investing great energy in avoiding responsibility", 
-                    "Boasting about achievements without putting your expertise to practical use", 
-                    "Lording it over others"
-                ]
-            },
-		"Elemental" : "Fire of Fire",
-      "Affirmation" : "\"I use my authority and experience to get things done faster.\"",
-	  "Questions to Ask" : ["How confident a leader am I?","How can I project more confidence?","How can I offer my expertise in ways that inspire others to follow me?"]
+      "fortune_telling": [
+        "This card represents an older man with a commanding, charismatic personality, likely born between November 13th and December 12th, who prefers to give directions and have them followed"
+      ],
+      "keywords": [
+        "creativity",
+        "ingenuity",
+        "achievement",
+        "direction"
+      ],
+      "meanings": {
+        "light": [
+          "Putting old things together in new and exciting ways",
+          "Coming up with unexpected solutions",
+          "Using your experience to solve puzzles and problems",
+          "Doing what you set out to do",
+          "Directing the efforts of others"
+        ],
+        "shadow": [
+          "Using your creativity to get out of honest work",
+          "Investing great energy in avoiding responsibility",
+          "Boasting about achievements without putting your expertise to practical use",
+          "Lording it over others"
+        ]
+      },
+      "Elemental": "Fire of Fire",
+      "Affirmation": "\"I use my authority and experience to get things done faster.\"",
+      "Questions to Ask": [
+        "How confident a leader am I?",
+        "How can I project more confidence?",
+        "How can I offer my expertise in ways that inspire others to follow me?"
+      ],
+      "hash64": "7e0c04f4d834a6b2892b43323707c9f093e675bd514b85c8000bc3f610a68b50"
     },
     {
       "name": "Ace of Pentacles",
@@ -2545,37 +2865,42 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p01.jpg",
-	  "fortune_telling": [
-                "Your health will improve", 
-                "The check you're looking for really is in the mail"
-            ], 
-            "keywords": [
-                "health", 
-                "wealth", 
-                "practicality", 
-                "receiving"
-            ], 
-            "meanings": {
-                "light": [
-                    "Outlining a plan for achieving prosperity", 
-                    "Becoming aware of opportunities to improve income or health", 
-                    "Realizing you have everything you need", 
-                    "Appreciating everything the Universe has given you", 
-                    "Receiving the perfect gift at the perfect time"
-                ], 
-                "shadow": [
-                    "Indulging in relentless consumerism", 
-                    "Wanting more, no matter how much you have", 
-                    "Obsessing on your account balance", 
-                    "Suffering from hypochondria", 
-                    "Consuming blessings without expressing gratitude", 
-                    "Taking what you want without concern for the needs of others"
-                ]
-            },
-		"Numerology" : "1 (The Origin: the starting point, the seed, opportunity)",
-      "Astrology" : "Capricorn, Taurus, Virgo",
-      "Affirmation" : "\"I am open to and thankful for my blessings.\"",
-	  "Questions to Ask" : ["If I made my decision based solely on practical concerns, what would my decision be?","What resources are available to me?","What will be the physical and financial impact of my decisions?"]
+      "fortune_telling": [
+        "Your health will improve",
+        "The check you're looking for really is in the mail"
+      ],
+      "keywords": [
+        "health",
+        "wealth",
+        "practicality",
+        "receiving"
+      ],
+      "meanings": {
+        "light": [
+          "Outlining a plan for achieving prosperity",
+          "Becoming aware of opportunities to improve income or health",
+          "Realizing you have everything you need",
+          "Appreciating everything the Universe has given you",
+          "Receiving the perfect gift at the perfect time"
+        ],
+        "shadow": [
+          "Indulging in relentless consumerism",
+          "Wanting more, no matter how much you have",
+          "Obsessing on your account balance",
+          "Suffering from hypochondria",
+          "Consuming blessings without expressing gratitude",
+          "Taking what you want without concern for the needs of others"
+        ]
+      },
+      "Numerology": "1 (The Origin: the starting point, the seed, opportunity)",
+      "Astrology": "Capricorn, Taurus, Virgo",
+      "Affirmation": "\"I am open to and thankful for my blessings.\"",
+      "Questions to Ask": [
+        "If I made my decision based solely on practical concerns, what would my decision be?",
+        "What resources are available to me?",
+        "What will be the physical and financial impact of my decisions?"
+      ],
+      "hash64": "59bfe95ec5a3cc195c20126c3981fdf668143550e3a3a1c84df11755c0e7238f"
     },
     {
       "name": "Two of Pentacles",
@@ -2583,38 +2908,43 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p02.jpg",
-	  "fortune_telling": [
-                "It's time to balance the budget", 
-                "Avoid the temptation to spend critical funds on frivolous goods"
-            ], 
-            "keywords": [
-                "evaluation", 
-                "decision", 
-                "budgeting", 
-                "diagnosis"
-            ], 
-            "meanings": {
-                "light": [
-                    "Weighing options", 
-                    "Comparing prices", 
-                    "Determining the value of one option over another", 
-                    "Juggling resources to make ends meet", 
-                    "Making difficult choices based on what's best for your body or your bankbook", 
-                    "Looking at the bottom line", 
-                    "Asking for a second opinion on health issues"
-                ], 
-                "shadow": [
-                    "Engaging in endless price comparison", 
-                    "Putting off a buying decision for fear of finding a slightly better value later on", 
-                    "Buying something without regard for value", 
-                    "Breaking your budget with unnecessary expenses", 
-                    "Engaging in behavior with no regard for how your body or bankbook will be impacted"
-                ]
-            },
-		"Numerology" : "2 (The Other: duality, division, debate)",
-      "Astrology" : "Jupiter in Capricorn",
-      "Affirmation" : "\"Before taking action, I consider costs.\"",
-	  "Questions to Ask" : ["What values govern my decisions?","How willing am I to sacrifice a little pleasure now in order to have more pleasure later on?","Given my current situation, which course of action will give me more of what I really need?"]
+      "fortune_telling": [
+        "It's time to balance the budget",
+        "Avoid the temptation to spend critical funds on frivolous goods"
+      ],
+      "keywords": [
+        "evaluation",
+        "decision",
+        "budgeting",
+        "diagnosis"
+      ],
+      "meanings": {
+        "light": [
+          "Weighing options",
+          "Comparing prices",
+          "Determining the value of one option over another",
+          "Juggling resources to make ends meet",
+          "Making difficult choices based on what's best for your body or your bankbook",
+          "Looking at the bottom line",
+          "Asking for a second opinion on health issues"
+        ],
+        "shadow": [
+          "Engaging in endless price comparison",
+          "Putting off a buying decision for fear of finding a slightly better value later on",
+          "Buying something without regard for value",
+          "Breaking your budget with unnecessary expenses",
+          "Engaging in behavior with no regard for how your body or bankbook will be impacted"
+        ]
+      },
+      "Numerology": "2 (The Other: duality, division, debate)",
+      "Astrology": "Jupiter in Capricorn",
+      "Affirmation": "\"Before taking action, I consider costs.\"",
+      "Questions to Ask": [
+        "What values govern my decisions?",
+        "How willing am I to sacrifice a little pleasure now in order to have more pleasure later on?",
+        "Given my current situation, which course of action will give me more of what I really need?"
+      ],
+      "hash64": "363b37535058f40c751e1e1ba909e624767de881e6d359320f84d6551fb4144e"
     },
     {
       "name": "Three of Pentacles",
@@ -2622,39 +2952,44 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p03.jpg",
-	  "fortune_telling": [
-                "A high-dollar contract is in your future", 
-                "If you work hard, you'll succeed"
-            ], 
-            "keywords": [
-                "expression", 
-                "production", 
-                "work", 
-                "contribution"
-            ], 
-            "meanings": {
-                "light": [
-                    "Finishing a project", 
-                    "Setting and meeting standards", 
-                    "Performing according to specifications", 
-                    "Making something others value", 
-                    "Creating something new", 
-                    "Doing your part in a group project", 
-                    "Delivering exactly what others have asked for"
-                ], 
-                "shadow": [
-                    "Pandering to the tastes of others", 
-                    "Failing to deliver what you've promised", 
-                    "Not delivering your best work unless closely supervised", 
-                    "Ignoring or breaking agreements with those who have invested in you", 
-                    "Refusing to do your part", 
-                    "Failing to abide by a clearly-outlined agreement with yourself or others"
-                ]
-            },
-		"Numerology" : "3 (The Result: expression, productivity, output)",
-      "Astrology" : "Mars in Capricorn",
-      "Affirmation" : "\"My work produces results.\"",
-	  "Questions to Ask" : ["How can I get more done?","What's expected of me? How large a role do I play in controlling those expectations?","What's been agreed to? How well has that agreement been followed?"]
+      "fortune_telling": [
+        "A high-dollar contract is in your future",
+        "If you work hard, you'll succeed"
+      ],
+      "keywords": [
+        "expression",
+        "production",
+        "work",
+        "contribution"
+      ],
+      "meanings": {
+        "light": [
+          "Finishing a project",
+          "Setting and meeting standards",
+          "Performing according to specifications",
+          "Making something others value",
+          "Creating something new",
+          "Doing your part in a group project",
+          "Delivering exactly what others have asked for"
+        ],
+        "shadow": [
+          "Pandering to the tastes of others",
+          "Failing to deliver what you've promised",
+          "Not delivering your best work unless closely supervised",
+          "Ignoring or breaking agreements with those who have invested in you",
+          "Refusing to do your part",
+          "Failing to abide by a clearly-outlined agreement with yourself or others"
+        ]
+      },
+      "Numerology": "3 (The Result: expression, productivity, output)",
+      "Astrology": "Mars in Capricorn",
+      "Affirmation": "\"My work produces results.\"",
+      "Questions to Ask": [
+        "How can I get more done?",
+        "What's expected of me? How large a role do I play in controlling those expectations?",
+        "What's been agreed to? How well has that agreement been followed?"
+      ],
+      "hash64": "bf8e534b5db43b9a904b2b25e955dc1018994a307456017eaaa3c7f3c596d735"
     },
     {
       "name": "Four of Pentacles",
@@ -2662,38 +2997,43 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p04.jpg",
-	  "fortune_telling": [
-                "A rainy day is coming\u2014it's time to save"
-            ], 
-            "keywords": [
-                "protection", 
-                "conservation", 
-                "preservation", 
-                "safety"
-            ], 
-            "meanings": {
-                "light": [
-                    "Saving for a rainy day", 
-                    "Fasting as part of a spiritual practice", 
-                    "Dieting in an effort to improve your body", 
-                    "Abstaining from sex as a way of honoring a spiritual tradition or personal promise", 
-                    "Being financially conservative", 
-                    "Establishing a trust fund", 
-                    "Opening a savings account"
-                ], 
-                "shadow": [
-                    "Being stingy", 
-                    "Refusing to spend money that needs to be spent", 
-                    "Withholding sex from your partner", 
-                    "Taking care of your own needs exclusively, without regard for the needs of others", 
-                    "Spending a dollar to save a penny", 
-                    "Failing to be a good manager of the blessings you've been given"
-                ]
-            },
-		"Numerology" : "4 (The Status Quo: stability, equality, persistence)",
-      "Astrology" : "Sun in Capricorn",
-      "Affirmation" : "\"I use my resources wisely.\"",
-	  "Questions to Ask" : ["What factors determine how conservative or generous you are?","What kinds of things must be preserved at all costs?","When is greediness or stinginess a good trait to have? When might generosity work against you?"]
+      "fortune_telling": [
+        "A rainy day is coming—it's time to save"
+      ],
+      "keywords": [
+        "protection",
+        "conservation",
+        "preservation",
+        "safety"
+      ],
+      "meanings": {
+        "light": [
+          "Saving for a rainy day",
+          "Fasting as part of a spiritual practice",
+          "Dieting in an effort to improve your body",
+          "Abstaining from sex as a way of honoring a spiritual tradition or personal promise",
+          "Being financially conservative",
+          "Establishing a trust fund",
+          "Opening a savings account"
+        ],
+        "shadow": [
+          "Being stingy",
+          "Refusing to spend money that needs to be spent",
+          "Withholding sex from your partner",
+          "Taking care of your own needs exclusively, without regard for the needs of others",
+          "Spending a dollar to save a penny",
+          "Failing to be a good manager of the blessings you've been given"
+        ]
+      },
+      "Numerology": "4 (The Status Quo: stability, equality, persistence)",
+      "Astrology": "Sun in Capricorn",
+      "Affirmation": "\"I use my resources wisely.\"",
+      "Questions to Ask": [
+        "What factors determine how conservative or generous you are?",
+        "What kinds of things must be preserved at all costs?",
+        "When is greediness or stinginess a good trait to have? When might generosity work against you?"
+      ],
+      "hash64": "f3ba7f18690af247d82d592f349e329f45784bd3a43e12738eccae4a6d46fbf4"
     },
     {
       "name": "Five of Pentacles",
@@ -2701,39 +3041,44 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p05.jpg",
-	  "fortune_telling": [
-                "Finances are getting tighter", 
-                "Prepare for a setback"
-            ], 
-            "keywords": [
-                "poverty", 
-                "destitution", 
-                "need", 
-                "crisis"
-            ], 
-            "meanings": {
-                "light": [
-                    "Recognizing your needs and taking action to fulfill them", 
-                    "Doing as much as you can do with what little you have", 
-                    "Admitting you need help", 
-                    "Embracing the aid that comes your way", 
-                    "Focusing on what you have versus what you don't", 
-                    "Looking for the light at the end of the tunnel"
-                ], 
-                "shadow": [
-                    "Exaggerating your financial or physical needs", 
-                    "Adopting a poverty mentality", 
-                    "Refusing to support yourself", 
-                    "Refusing offers of support", 
-                    "Playing the martyr", 
-                    "Turning down opportunities to improve your health or finances", 
-                    "Wallowing in misery"
-                ]
-            },
-		"Numerology" : "5 (The Catalyst: instability, resistance, confrontation)",
-      "Astrology" : "Mercury in Taurus",
-      "Affirmation" : "\"I have faith that what I need will appear.\"",
-	  "Questions to Ask" : ["What critical resources do I lack?","What people or groups would come to my aid if I asked?","How might an impoverished spirit be impacting my physical or financial condition?"]
+      "fortune_telling": [
+        "Finances are getting tighter",
+        "Prepare for a setback"
+      ],
+      "keywords": [
+        "poverty",
+        "destitution",
+        "need",
+        "crisis"
+      ],
+      "meanings": {
+        "light": [
+          "Recognizing your needs and taking action to fulfill them",
+          "Doing as much as you can do with what little you have",
+          "Admitting you need help",
+          "Embracing the aid that comes your way",
+          "Focusing on what you have versus what you don't",
+          "Looking for the light at the end of the tunnel"
+        ],
+        "shadow": [
+          "Exaggerating your financial or physical needs",
+          "Adopting a poverty mentality",
+          "Refusing to support yourself",
+          "Refusing offers of support",
+          "Playing the martyr",
+          "Turning down opportunities to improve your health or finances",
+          "Wallowing in misery"
+        ]
+      },
+      "Numerology": "5 (The Catalyst: instability, resistance, confrontation)",
+      "Astrology": "Mercury in Taurus",
+      "Affirmation": "\"I have faith that what I need will appear.\"",
+      "Questions to Ask": [
+        "What critical resources do I lack?",
+        "What people or groups would come to my aid if I asked?",
+        "How might an impoverished spirit be impacting my physical or financial condition?"
+      ],
+      "hash64": "5caa7e4e50966c0ae013927a172b799351b29252272d4fb8b75f82738d860a25"
     },
     {
       "name": "Six of Pentacles",
@@ -2741,39 +3086,44 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p06.jpg",
-	  "fortune_telling": [
-                "When you need help, ask for it", 
-                "Remember, though: what you receive may be limited by what you've given to others in the past"
-            ], 
-            "keywords": [
-                "charity", 
-                "fairness", 
-                "cooperation", 
-                "sharing"
-            ], 
-            "meanings": {
-                "light": [
-                    "Giving time, money, or effort to a charity", 
-                    "Taking part in a group effort", 
-                    "Lending your resources to others without expecting anything in return", 
-                    "Making sure everyone is treated equally", 
-                    "Working together toward a common goal", 
-                    "Redistributing wealth, time, or attention", 
-                    "Tithing", 
-                    "Sharing credit for your success"
-                ], 
-                "shadow": [
-                    "Making a loan as a means of gaining control over someone", 
-                    "Using charitable acts to draw attention to yourself", 
-                    "Dividing work or resources unfairly", 
-                    "Failing to do your part in a group effort", 
-                    "Ignoring obligations and commitments"
-                ]
-            },
-		"Numerology" : "6 (The Adjustment: cooperation, collaboration, interaction)",
-      "Astrology" : "Moon in Taurus",
-      "Affirmation" : "\"Knowing I will receive more, I share my resources freely.\"",
-	  "Questions to Ask" : ["How do I feel about charity? About giving it? About receiving it?","How can I know if I'm treating others fairly?","What could I give that no one else can?"]
+      "fortune_telling": [
+        "When you need help, ask for it",
+        "Remember, though: what you receive may be limited by what you've given to others in the past"
+      ],
+      "keywords": [
+        "charity",
+        "fairness",
+        "cooperation",
+        "sharing"
+      ],
+      "meanings": {
+        "light": [
+          "Giving time, money, or effort to a charity",
+          "Taking part in a group effort",
+          "Lending your resources to others without expecting anything in return",
+          "Making sure everyone is treated equally",
+          "Working together toward a common goal",
+          "Redistributing wealth, time, or attention",
+          "Tithing",
+          "Sharing credit for your success"
+        ],
+        "shadow": [
+          "Making a loan as a means of gaining control over someone",
+          "Using charitable acts to draw attention to yourself",
+          "Dividing work or resources unfairly",
+          "Failing to do your part in a group effort",
+          "Ignoring obligations and commitments"
+        ]
+      },
+      "Numerology": "6 (The Adjustment: cooperation, collaboration, interaction)",
+      "Astrology": "Moon in Taurus",
+      "Affirmation": "\"Knowing I will receive more, I share my resources freely.\"",
+      "Questions to Ask": [
+        "How do I feel about charity? About giving it? About receiving it?",
+        "How can I know if I'm treating others fairly?",
+        "What could I give that no one else can?"
+      ],
+      "hash64": "8a072891ea56785b697f2740206580a582dcf1ebfb13acc5cf4faf2c3e3d66e5"
     },
     {
       "name": "Seven of Pentacles",
@@ -2781,38 +3131,43 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p07.jpg",
-	  "fortune_telling": [
-                "Things won't work out as expected", 
-                "Pick up the pieces and prepare to move on"
-            ], 
-            "keywords": [
-                "assessment", 
-                "evaluation", 
-                "re-evaluation", 
-                "reflection"
-            ], 
-            "meanings": {
-                "light": [
-                    "Measuring progress toward your goal", 
-                    "Looking at results with an eye toward improving performance", 
-                    "Asking, \"How happy am I?\"",
-                    "Coming up with ideas for improving your health or prosperity", 
-                    "Deciding it's time for a change", 
-                    "Expressing an honest opinion"
-                ], 
-                "shadow": [
-                    "Becoming distracted by melancholy thoughts", 
-                    "Longing for \"the good old days\"",
-                    "Beating yourself up over lost opportunities", 
-                    "Judging your own work harshly", 
-                    "Holding others to inappropriate standards", 
-                    "Refusing to take part in a project, then whining about the quality of the outcome"
-                ]
-            },
-		"Numerology" : "7 (The Motive: imagination, inner work, psychology)",
-      "Astrology" : "Saturn in Taurus",
-      "Affirmation" : "\"To stay on target, I measure my progress.\"",
-	  "Questions to Ask" : ["To what extent have I fulfilled my own expectations?","What are the terms of success?","How can I be happier with the progress I've made?"]
+      "fortune_telling": [
+        "Things won't work out as expected",
+        "Pick up the pieces and prepare to move on"
+      ],
+      "keywords": [
+        "assessment",
+        "evaluation",
+        "re-evaluation",
+        "reflection"
+      ],
+      "meanings": {
+        "light": [
+          "Measuring progress toward your goal",
+          "Looking at results with an eye toward improving performance",
+          "Asking, \"How happy am I?\"",
+          "Coming up with ideas for improving your health or prosperity",
+          "Deciding it's time for a change",
+          "Expressing an honest opinion"
+        ],
+        "shadow": [
+          "Becoming distracted by melancholy thoughts",
+          "Longing for \"the good old days\"",
+          "Beating yourself up over lost opportunities",
+          "Judging your own work harshly",
+          "Holding others to inappropriate standards",
+          "Refusing to take part in a project, then whining about the quality of the outcome"
+        ]
+      },
+      "Numerology": "7 (The Motive: imagination, inner work, psychology)",
+      "Astrology": "Saturn in Taurus",
+      "Affirmation": "\"To stay on target, I measure my progress.\"",
+      "Questions to Ask": [
+        "To what extent have I fulfilled my own expectations?",
+        "What are the terms of success?",
+        "How can I be happier with the progress I've made?"
+      ],
+      "hash64": "550498f2f4e33f2bbbb33ca8cd889365ad5857ae9d778f1e7371bf05408f8aa0"
     },
     {
       "name": "Eight of Pentacles",
@@ -2820,40 +3175,45 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p08.jpg",
-	  "fortune_telling": [
-                "Stop over-analyzing, researching, and outlining", 
-                "Buckle down and get the work done"
-            ], 
-            "keywords": [
-                "effort", 
-                "work diligence", 
-                "skill"
-            ], 
-            "meanings": {
-                "light": [
-                    "Doing your best", 
-                    "Bringing enthusiasm and zeal to your work", 
-                    "Making an effort to be the best you can be", 
-                    "Finding the work that is right for you", 
-                    "Taking care of the small details", 
-                    "Becoming a finely skilled craftsperson", 
-                    "Building something with your hands", 
-                    "Making a handmade gift"
-                ], 
-                "shadow": [
-                    "Working yourself to death", 
-                    "Doing a half-hearted or sloppy job", 
-                    "Continuing in a job you hate", 
-                    "Buying thoughtless gifts", 
-                    "Producing work with shoddy craftsmanship", 
-                    "Rushing through your work", 
-                    "Rejecting opportunities to learn more about your craft"
-                ]
-            },
-		"Numerology" : "8 (The Action: movement, outer work, swiftness)",
-      "Astrology" : "Sun in Virgo",
-      "Affirmation" : "\"I give myself wholeheartedly to the task of the moment.\"",
-	   "Questions to Ask" : ["How long has it been since you were \"lost in your work?\"","How can you improve your level of dedication and focus?","What work do you do best? What about that work appeals to you?"]
+      "fortune_telling": [
+        "Stop over-analyzing, researching, and outlining",
+        "Buckle down and get the work done"
+      ],
+      "keywords": [
+        "effort",
+        "work diligence",
+        "skill"
+      ],
+      "meanings": {
+        "light": [
+          "Doing your best",
+          "Bringing enthusiasm and zeal to your work",
+          "Making an effort to be the best you can be",
+          "Finding the work that is right for you",
+          "Taking care of the small details",
+          "Becoming a finely skilled craftsperson",
+          "Building something with your hands",
+          "Making a handmade gift"
+        ],
+        "shadow": [
+          "Working yourself to death",
+          "Doing a half-hearted or sloppy job",
+          "Continuing in a job you hate",
+          "Buying thoughtless gifts",
+          "Producing work with shoddy craftsmanship",
+          "Rushing through your work",
+          "Rejecting opportunities to learn more about your craft"
+        ]
+      },
+      "Numerology": "8 (The Action: movement, outer work, swiftness)",
+      "Astrology": "Sun in Virgo",
+      "Affirmation": "\"I give myself wholeheartedly to the task of the moment.\"",
+      "Questions to Ask": [
+        "How long has it been since you were \"lost in your work?\"",
+        "How can you improve your level of dedication and focus?",
+        "What work do you do best? What about that work appeals to you?"
+      ],
+      "hash64": "ae58ffb8d688bbf7c0223f967c5653a3d5346216a4f6aa3e9d67e97b11217e5e"
     },
     {
       "name": "Nine of Pentacles",
@@ -2861,36 +3221,41 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p09.jpg",
-	  "fortune_telling": [
-                "Until you appreciate what you have, you won't have any luck getting more"
-            ], 
-            "keywords": [
-                "training", 
-                "discipline", 
-                "confidence", 
-                "enough"
-            ], 
-            "meanings": {
-                "light": [
-                    "Investing time in learning or teaching a difficult task", 
-                    "Restraining yourself from physical or financial extremes", 
-                    "Making sacrifices as a way of achieving larger goals", 
-                    "Breaking a complex task down into simple steps", 
-                    "Wanting what you have", 
-                    "Knowing the difference between needs and wants"
-                ], 
-                "shadow": [
-                    "Being assigned to a task without being trained to perform it", 
-                    "Pursuing a position for which you are not qualified", 
-                    "Disregarding requirements", 
-                    "Refusing to dedicate adequate time or attention when learning about something or someone new", 
-                    "Always craving more"
-                ]
-            },
-		"Numerology" : "9 (The Completion: fullness, readiness, ripeness)",
-      "Astrology" : "Venus in Virgo",
-      "Affirmation" : "\"I know enough to be confident in my decisions.\"",
-	  "Questions to Ask" : ["If you could not have what you want, how would you make do?","Could you make a complex task easier by breaking it down into smaller steps?","How patient are you during the learning process? With yourself? With others?"]
+      "fortune_telling": [
+        "Until you appreciate what you have, you won't have any luck getting more"
+      ],
+      "keywords": [
+        "training",
+        "discipline",
+        "confidence",
+        "enough"
+      ],
+      "meanings": {
+        "light": [
+          "Investing time in learning or teaching a difficult task",
+          "Restraining yourself from physical or financial extremes",
+          "Making sacrifices as a way of achieving larger goals",
+          "Breaking a complex task down into simple steps",
+          "Wanting what you have",
+          "Knowing the difference between needs and wants"
+        ],
+        "shadow": [
+          "Being assigned to a task without being trained to perform it",
+          "Pursuing a position for which you are not qualified",
+          "Disregarding requirements",
+          "Refusing to dedicate adequate time or attention when learning about something or someone new",
+          "Always craving more"
+        ]
+      },
+      "Numerology": "9 (The Completion: fullness, readiness, ripeness)",
+      "Astrology": "Venus in Virgo",
+      "Affirmation": "\"I know enough to be confident in my decisions.\"",
+      "Questions to Ask": [
+        "If you could not have what you want, how would you make do?",
+        "Could you make a complex task easier by breaking it down into smaller steps?",
+        "How patient are you during the learning process? With yourself? With others?"
+      ],
+      "hash64": "5ad991fa4aef04c18895b7fbea8d12b26d5428ce3e160b1c173a932d15834cdd"
     },
     {
       "name": "Ten of Pentacles",
@@ -2898,37 +3263,42 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p10.jpg",
-	  "fortune_telling": [
-                "Big money is in the near future", 
-                "Expect a powerful blessing to come your way"
-            ], 
-            "keywords": [
-                "wealth", 
-                "abundance", 
-                "acquisition", 
-                "greed"
-            ], 
-            "meanings": {
-                "light": [
-                    "Celebrating your physical and financial blessings", 
-                    "Realizing how lucky or how blessed you are", 
-                    "Being satisfied with your physical and financial achievements", 
-                    "Taking best advantage of \"times of plenty\"",
-                    "Enjoying a feast", 
-                    "Showering friends or family with gifts"
-                ], 
-                "shadow": [
-                    "Spending all of your money on extravagant gifts and possessions", 
-                    "Trying too hard to impress others with your wealth or physique", 
-                    "Giving an inappropriately expensive gift as a means of currying favor", 
-                    "Obsessing on matters of weight, health, or finance", 
-                    "Always asking, \"What's in it for me?\""
-                ]
-            },
-		"Numerology" : "10 (The End: finality, completion, exhaustion)",
-      "Astrology" : "Mercury in Virgo",
-      "Affirmation" : "\"I keep physical and financial matters in perspective.\"",
-	  "Questions to Ask" : ["How much stuff do I really need?","How do I feel about wealth and abundance? How do I define these terms?","How might shedding some possessions open room for growth?"]
+      "fortune_telling": [
+        "Big money is in the near future",
+        "Expect a powerful blessing to come your way"
+      ],
+      "keywords": [
+        "wealth",
+        "abundance",
+        "acquisition",
+        "greed"
+      ],
+      "meanings": {
+        "light": [
+          "Celebrating your physical and financial blessings",
+          "Realizing how lucky or how blessed you are",
+          "Being satisfied with your physical and financial achievements",
+          "Taking best advantage of \"times of plenty\"",
+          "Enjoying a feast",
+          "Showering friends or family with gifts"
+        ],
+        "shadow": [
+          "Spending all of your money on extravagant gifts and possessions",
+          "Trying too hard to impress others with your wealth or physique",
+          "Giving an inappropriately expensive gift as a means of currying favor",
+          "Obsessing on matters of weight, health, or finance",
+          "Always asking, \"What's in it for me?\""
+        ]
+      },
+      "Numerology": "10 (The End: finality, completion, exhaustion)",
+      "Astrology": "Mercury in Virgo",
+      "Affirmation": "\"I keep physical and financial matters in perspective.\"",
+      "Questions to Ask": [
+        "How much stuff do I really need?",
+        "How do I feel about wealth and abundance? How do I define these terms?",
+        "How might shedding some possessions open room for growth?"
+      ],
+      "hash64": "b59d733aeee343be06af913e5028a627370d14f27fb322345001caa3275a1dfa"
     },
     {
       "name": "Page of Pentacles",
@@ -2936,37 +3306,42 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p11.jpg",
-	  "fortune_telling": [
-                "This card represents a young man or woman with an earthy, practical demeanor, likely born an Aries, Taurus, or Gemini, who playfully encourages you to take financial or sexual risks"
-            ], 
-            "keywords": [
-                "practicality", 
-                "prosperity", 
-                "learning", 
-                "growth", 
-                "adolescence"
-            ], 
-            "meanings": {
-                "light": [
-                    "Learning the value of a dollar", 
-                    "Starting a savings plan", 
-                    "Taking the first steps toward getting out of debt", 
-                    "Learning new physical tasks", 
-                    "Discovering your sexuality", 
-                    "Launching a diet, a weight-lifting program, or a health-related effort", 
-                    "Learning by doing"
-                ], 
-                "shadow": [
-                    "Trying to appear healthier or wealthier than you really are", 
-                    "Spending money carelessly", 
-                    "Living strictly for today, with no thought of tomorrow", 
-                    "Possessing immature attitudes toward sex and sexuality", 
-                    "Using wealth or beauty as an excuse for not having to learn and grow"
-                ]
-            },
-		"Elemental" : "Earth of Earth.",
-      "Affirmation" : "\"I am physically and financially responsible.\"",
-	  "Questions to Ask" : ["How can you get more financial or sexual experience without risking your livelihood or health?","How might hands-on learning play a role in your situation?","What's the most practical choice you could make?"]
+      "fortune_telling": [
+        "This card represents a young man or woman with an earthy, practical demeanor, likely born an Aries, Taurus, or Gemini, who playfully encourages you to take financial or sexual risks"
+      ],
+      "keywords": [
+        "practicality",
+        "prosperity",
+        "learning",
+        "growth",
+        "adolescence"
+      ],
+      "meanings": {
+        "light": [
+          "Learning the value of a dollar",
+          "Starting a savings plan",
+          "Taking the first steps toward getting out of debt",
+          "Learning new physical tasks",
+          "Discovering your sexuality",
+          "Launching a diet, a weight-lifting program, or a health-related effort",
+          "Learning by doing"
+        ],
+        "shadow": [
+          "Trying to appear healthier or wealthier than you really are",
+          "Spending money carelessly",
+          "Living strictly for today, with no thought of tomorrow",
+          "Possessing immature attitudes toward sex and sexuality",
+          "Using wealth or beauty as an excuse for not having to learn and grow"
+        ]
+      },
+      "Elemental": "Earth of Earth.",
+      "Affirmation": "\"I am physically and financially responsible.\"",
+      "Questions to Ask": [
+        "How can you get more financial or sexual experience without risking your livelihood or health?",
+        "How might hands-on learning play a role in your situation?",
+        "What's the most practical choice you could make?"
+      ],
+      "hash64": "ef449887c959f678c4778e5ad8beba9161ebb7d6661514bbe40c6deb4260a092"
     },
     {
       "name": "Knight of Pentacles",
@@ -2974,40 +3349,45 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p12.jpg",
-	  "fortune_telling": [
-                "A stingy person may chide you for spending money", 
-                "Be prepared to defend an economic or sexual decision"
-            ], 
-            "keywords": [
-                "caution", 
-                "focus", 
-                "realism", 
-                "invention"
-            ], 
-            "meanings": {
-                "light": [
-                    "Spending money wisely", 
-                    "Saving for a rainy day", 
-                    "Paying close attention to physical or financial details", 
-                    "Knowing where every dollar goes", 
-                    "Having safe sex", 
-                    "Preferring facts to \"good feelings\"",
-                    "Finding creative ways to \"make do\" with resources on hand", 
-                    "Completing a new invention"
-                ], 
-                "shadow": [
-                    "Throwing caution to the four winds", 
-                    "Spending without regard for consequence", 
-                    "Spending on luxury when necessities are lacking", 
-                    "Escaping stress by spending money", 
-                    "Obsessing on tiny physical or financial details", 
-                    "Perpetually chasing after some new bauble", 
-                    "Copying another's work and claiming it as your own"
-                ]
-            },
-		"Elemental" : "Air of Earth.",
-      "Affirmation" : "\"I temper my actions with cautious optimism.\"",
-	  "Questions to Ask" : ["What's the difference between caution and fear?","How can I evaluate the practicality of my own ideas and methods?","How realistic are my goals?"]
+      "fortune_telling": [
+        "A stingy person may chide you for spending money",
+        "Be prepared to defend an economic or sexual decision"
+      ],
+      "keywords": [
+        "caution",
+        "focus",
+        "realism",
+        "invention"
+      ],
+      "meanings": {
+        "light": [
+          "Spending money wisely",
+          "Saving for a rainy day",
+          "Paying close attention to physical or financial details",
+          "Knowing where every dollar goes",
+          "Having safe sex",
+          "Preferring facts to \"good feelings\"",
+          "Finding creative ways to \"make do\" with resources on hand",
+          "Completing a new invention"
+        ],
+        "shadow": [
+          "Throwing caution to the four winds",
+          "Spending without regard for consequence",
+          "Spending on luxury when necessities are lacking",
+          "Escaping stress by spending money",
+          "Obsessing on tiny physical or financial details",
+          "Perpetually chasing after some new bauble",
+          "Copying another's work and claiming it as your own"
+        ]
+      },
+      "Elemental": "Air of Earth.",
+      "Affirmation": "\"I temper my actions with cautious optimism.\"",
+      "Questions to Ask": [
+        "What's the difference between caution and fear?",
+        "How can I evaluate the practicality of my own ideas and methods?",
+        "How realistic are my goals?"
+      ],
+      "hash64": "75934f832c5c8088e9d404a6ecc4a893223cc5cf9cd223714a39b79bea2f3aa6"
     },
     {
       "name": "Queen of Pentacles",
@@ -3015,36 +3395,41 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p13.jpg",
-	  "fortune_telling": [
-                "This card represents a woman with an expansive, sensual nature, likely born between December 13th and 31st, who uses sensual appeal and the promise of reward to sway others to her point of view"
-            ], 
-            "keywords": [
-                "luxury", 
-                "comfort", 
-                "resourcefulness", 
-                "generosity", 
-                "prosperity"
-            ], 
-            "meanings": {
-                "light": [
-                    "Appreciating fine food, fine wine, beautiful art, beautiful bodies, or any of the better things in life", 
-                    "Reveling in healthy sexuality", 
-                    "Treating yourself", 
-                    "Splurging on the occasional \"nice to have\" item", 
-                    "Rewarding someone with compensation above and beyond expectations", 
-                    "Having it all"
-                ], 
-                "shadow": [
-                    "Indulging in gluttony or greediness", 
-                    "Becoming insatiable", 
-                    "Blunting the impact of treats by indulging in them too often", 
-                    "Providing physical comfort without providing for emotional needs", 
-                    "Allowing a feeling of entitlement to distort your gratitude for what you're given"
-                ]
-            },
-		"Elemental" : "Water of Earth.",
-      "Affirmation" : "\"I relish the best this world has to offer.\"",
-	  "Questions to Ask" : ["How do I define luxury?","To what extent am I capable of reveling in sensual pleasure?","What would I have to give up in order to \"have it all?\""]
+      "fortune_telling": [
+        "This card represents a woman with an expansive, sensual nature, likely born between December 13th and 31st, who uses sensual appeal and the promise of reward to sway others to her point of view"
+      ],
+      "keywords": [
+        "luxury",
+        "comfort",
+        "resourcefulness",
+        "generosity",
+        "prosperity"
+      ],
+      "meanings": {
+        "light": [
+          "Appreciating fine food, fine wine, beautiful art, beautiful bodies, or any of the better things in life",
+          "Reveling in healthy sexuality",
+          "Treating yourself",
+          "Splurging on the occasional \"nice to have\" item",
+          "Rewarding someone with compensation above and beyond expectations",
+          "Having it all"
+        ],
+        "shadow": [
+          "Indulging in gluttony or greediness",
+          "Becoming insatiable",
+          "Blunting the impact of treats by indulging in them too often",
+          "Providing physical comfort without providing for emotional needs",
+          "Allowing a feeling of entitlement to distort your gratitude for what you're given"
+        ]
+      },
+      "Elemental": "Water of Earth.",
+      "Affirmation": "\"I relish the best this world has to offer.\"",
+      "Questions to Ask": [
+        "How do I define luxury?",
+        "To what extent am I capable of reveling in sensual pleasure?",
+        "What would I have to give up in order to \"have it all?\""
+      ],
+      "hash64": "5e80f5d388ca35da2d89482514bf28e3362ec7d0d79eb9f0a72f71d55b7a2cba"
     },
     {
       "name": "King of Pentacles",
@@ -3052,37 +3437,42 @@
       "arcana": "Minor Arcana",
       "suit": "Pentacles",
       "img": "p14.jpg",
-	  "fortune_telling": [
-                "This card represents an older man with a financially, socially, and politically conservative spirit, likely born between August 12th and September 11th, who is known for putting his money where his mouth is"
-            ], 
-            "keywords": [
-                "stability", 
-                "dependability", 
-                "confidence", 
-                "intervention"
-            ], 
-            "meanings": {
-                "light": [
-                    "Becoming debt-free", 
-                    "Having more than enough to get by", 
-                    "Making contributions to a savings plan", 
-                    "Taking a new job with an eye toward advancing your career", 
-                    "Buying life or health insurance", 
-                    "Being confident in the bedroom", 
-                    "Taking on the role of enforcer when called upon to do so"
-                ], 
-                "shadow": [
-                    "Becoming so conservative you resist all change on principle alone", 
-                    "Ignoring innovations in the name of preserving tradition", 
-                    "Being smug or cocky", 
-                    "Becoming ruthlessly dedicated to profit or pleasure", 
-                    "Being sexually selfish", 
-                    "Bossing others around, especially when you're not empowered to do so"
-                ]
-            },
-		"Elemental" : "Fire of Earth.",
-      "Affirmation" : "\"I embody confidence and fairness.\"",
-	  "Questions to Ask" : ["How can you handle expenses with greater confidence and maturity?","How dependable are you? How dependable would others say you are?","To what extent is a conservative viewpoint valuable? At what point does it become more of a burden than a blessing?"]
+      "fortune_telling": [
+        "This card represents an older man with a financially, socially, and politically conservative spirit, likely born between August 12th and September 11th, who is known for putting his money where his mouth is"
+      ],
+      "keywords": [
+        "stability",
+        "dependability",
+        "confidence",
+        "intervention"
+      ],
+      "meanings": {
+        "light": [
+          "Becoming debt-free",
+          "Having more than enough to get by",
+          "Making contributions to a savings plan",
+          "Taking a new job with an eye toward advancing your career",
+          "Buying life or health insurance",
+          "Being confident in the bedroom",
+          "Taking on the role of enforcer when called upon to do so"
+        ],
+        "shadow": [
+          "Becoming so conservative you resist all change on principle alone",
+          "Ignoring innovations in the name of preserving tradition",
+          "Being smug or cocky",
+          "Becoming ruthlessly dedicated to profit or pleasure",
+          "Being sexually selfish",
+          "Bossing others around, especially when you're not empowered to do so"
+        ]
+      },
+      "Elemental": "Fire of Earth.",
+      "Affirmation": "\"I embody confidence and fairness.\"",
+      "Questions to Ask": [
+        "How can you handle expenses with greater confidence and maturity?",
+        "How dependable are you? How dependable would others say you are?",
+        "To what extent is a conservative viewpoint valuable? At what point does it become more of a burden than a blessing?"
+      ],
+      "hash64": "d1ceb7ea5d40db258d809dbe7951d3d7da110e78a69b122d3f4760a1efc086e1"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace misconfigured hash script with a functional version
- regenerate the tarot deck JSON to include `hash64` for each card

## Testing
- `npm install`
- `npm test --silent` *(fails: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68410e1251c08326968fcad8e1ad8739