### PR TITLE
Fix random Tao line selection

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,8 @@ function getAvestaLine(avesta) {
 }
 
 function getTaoLine(tao) {
-  return `📜 Chapter ${tao.chapter} — ${tao.text}`;
+  const line = getRandomFromObject(tao);
+  return `📜 Chapter ${line.chapter} — ${line.text}`;
 }
 
 function getIChingSummary(iching) {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+beforeAll(() => {
+  global.IntersectionObserver = class {
+    observe() {}
+    disconnect() {}
+  };
+});
+
+test('renders forest interlude continue button', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Continue Your Journey/i })).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- fix `getTaoLine` so it chooses a random entry before formatting
- mock `IntersectionObserver` in tests and update the assertion

## Testing
- `npm install --silent`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68410e128d9c832682b3678b6d1efa21