### PR TITLE
Fix ForestInterlude animations

### DIFF
--- a/src/data/ForestInterlude.jsx
+++ b/src/data/ForestInterlude.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import poemForest from "./poemForest.json";
-import "./ForestInterlude.css";
+import "../ForestInterlude.css";
 
 export default function ForestInterlude({ onComplete }) {
   const containerRef = useRef(null);


### PR DESCRIPTION
## Summary
- import animation styles from the correct stylesheet so that the Forest Interlude poem lines animate

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410e12749c8326a8ff9ecd9179c26d