### PR TITLE
Add unlimited card draw option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Moon UI Divination Portal
 
-Moon UI Divination Portal is an experimental tarot reader and text oracle built with React and Tailwind CSS.  It presents a short cosmic intro followed by a sequential three‑card draw.  Each card is paired with lines from sacred texts to inspire reflection.
+Moon UI Divination Portal is an experimental tarot reader and text oracle built with React and Tailwind CSS.  It presents a short cosmic intro followed by either a traditional three‑card draw or an unlimited reading for deeper exploration.  Each card is paired with lines from sacred texts to inspire reflection.
 
 ## Features
 
 - Animated "Galactic Scroll" intro screen.
 - Tarot cards drawn from `src/data/deckTarot.json`.
 - Quotes from the Avesta, Tao Te Ching and I Ching shown with each card.
+- Choose between a 3‑card reading or an unlimited draw for ongoing clarity.
 - Cards appear one by one on request with a floating animation.
 
 ## Getting Started
@@ -22,7 +23,7 @@ Open <http://localhost:3000> in your browser.  Use `npm run build` to create a p
 
 ## Usage
 
-Click **Reveal 3 Cards** to shuffle the deck and display the first card.  Use **Reveal Next Card** to show each remaining card in order.  When all three cards are shown you can draw another set.
+Choose **Reveal 3 Cards** for a traditional past‑present‑future spread or **Unlimited Clarity** to pull cards one after another.  Use **Reveal Next Card** to continue drawing until you are satisfied, then start a new reading whenever you wish.
 
 ## Project Structure
 

--- a/src/App.js
+++ b/src/App.js
@@ -36,9 +36,10 @@ function getMeaning(card) {
 export default function App() {
   const [cards, setCards] = useState([]);
   const [revealed, setRevealed] = useState(0);
-  const [texts, setTexts] = useState({ tao: "", iching: "", avesta: "" });
+  const [texts, setTexts] = useState([]);
   const [showIntro, setShowIntro] = useState(true);
   const [userHash, setUserHash] = useState(null);
+  const [mode, setMode] = useState("three");
 
   useEffect(() => {
     fetch('/api/userHash')
@@ -48,24 +49,26 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    getFreshTexts();
+    // load initial sacred texts for first draw
+    fetchTextSet().then(({ avesta, tao, iching }) => {
+      setTexts([avesta, tao, iching]);
+    });
   }, []);
 
-  function getFreshTexts() {
-    Promise.all([
+  function fetchTextSet() {
+    return Promise.all([
       fetch("/data/avesta.json").then(res => res.json()),
       fetch("/data/tao464.json").then(res => res.json()),
       fetch("/data/iching.json").then(res => res.json())
     ])
-      .then(([avestaData, taoData, ichingData]) => {
-        setTexts({
-          avesta: getAvestaLine(avestaData),
-          tao: getTaoLine(taoData),
-          iching: getIChingSummary(ichingData)
-        });
-      })
+      .then(([avestaData, taoData, ichingData]) => ({
+        avesta: getAvestaLine(avestaData),
+        tao: getTaoLine(taoData),
+        iching: getIChingSummary(ichingData)
+      }))
       .catch(err => {
         console.error("Failed to load sacred texts:", err);
+        return { avesta: "", tao: "", iching: "" };
       });
   }
 
@@ -83,14 +86,44 @@ export default function App() {
     
     setCards(selectedCards);
     setRevealed(1);
-    getFreshTexts();
+    setMode("three");
+    fetchTextSet().then(({ avesta, tao, iching }) => {
+      setTexts([avesta, tao, iching]);
+    });
+  }
+
+  function handleDrawUnlimited() {
+    const shuffled = [...deckTarot.cards].sort(() => 0.5 - Math.random());
+    setCards(shuffled);
+    setRevealed(1);
+    setMode("unlimited");
+    fetchTextSet().then(({ avesta, tao, iching }) => {
+      const options = [avesta, tao, iching];
+      setTexts([options[Math.floor(Math.random() * options.length)]]);
+    });
   }
 
   function handleRevealNext() {
-    setRevealed(r => Math.min(r + 1, cards.length));
+    setRevealed(r => {
+      const next = Math.min(r + 1, cards.length);
+      if (mode === "unlimited" && next > texts.length) {
+        fetchTextSet().then(({ avesta, tao, iching }) => {
+          const opts = [avesta, tao, iching];
+          setTexts(prev => [...prev, opts[Math.floor(Math.random() * opts.length)]]);
+        });
+      }
+      return next;
+    });
   }
 
   const labels = ["Avesta (Past)", "Tao Te Ching (Present)", "I Ching (Future)"];
+
+  function getLabel(index) {
+    if (mode === "three") {
+      return labels[index] || `Card ${index + 1}`;
+    }
+    return `Card ${index + 1}`;
+  }
 
   return showIntro ? (
     <GalacticScroll onComplete={() => setShowIntro(false)} />
@@ -114,20 +147,27 @@ export default function App() {
         {cards.length === 0 ? (
           <>
             <p className="portal-subtext">Shall we draw wisdom from the unseen?</p>
-            <button className="portal-button" onClick={handleDrawThree}>
-              Reveal 3 Cards
-            </button>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <button className="portal-button" onClick={handleDrawThree}>
+                Reveal 3 Cards
+              </button>
+              <button className="portal-button" onClick={handleDrawUnlimited}>
+                Unlimited Clarity
+              </button>
+            </div>
           </>
         ) : (
           <div className="card-group">
             {cards.slice(0, revealed).map((card, i) => (
               <div key={card.img || i} className="card-box float-in">
-                <h2 className="card-title">{labels[i]} — {card.name}</h2>
+                <h2 className="card-title">{getLabel(i)} — {card.name}</h2>
                 <div className="card-inner">
                   <img src={getImagePath(card)} alt={card.name} className="card-image" />
                   <div className="card-texts">
                     <pre className="card-meaning">{getMeaning(card)}</pre>
-                    <p className="card-sacred-text fade-in">{Object.values(texts)[i]}</p>
+                    {texts[i] && (
+                      <p className="card-sacred-text fade-in">{texts[i]}</p>
+                    )}
                   </div>
                 </div>
               </div>
@@ -137,9 +177,14 @@ export default function App() {
                 Reveal Next Card
               </button>
             ) : (
-              <button className="draw-again" onClick={handleDrawThree}>
-                Draw 3 new cards
-              </button>
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <button className="draw-again" onClick={handleDrawThree}>
+                  Draw 3 new cards
+                </button>
+                <button className="draw-again" onClick={handleDrawUnlimited}>
+                  Unlimited draw
+                </button>
+              </div>
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- allow querent to choose a 3‑card reading or unlimited draws
- adjust labels and fetch random sacred text for unlimited mode
- update README with new feature and usage info

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68503b415e848326a46dff1cab4bbc07